### PR TITLE
Reduce runtime and memory usage on specificity queries

### DIFF
--- a/dxguidedesign/alignment.py
+++ b/dxguidedesign/alignment.py
@@ -292,6 +292,10 @@ class Alignment:
             suitable_guides = []
             for s, idx in seq_rows:
                 if sum(s.count(c) for c in ['A', 'T', 'C', 'G']) == len(s):
+                    if (guide_is_suitable_fn is not None and
+                            guide_is_suitable_fn(s) is False):
+                        # Skip s, which is not suitable
+                        continue
                     # s has no ambiguity and is a suitable guide
                     if idx in selected_cluster_idxs:
                         # Pick s as the guide

--- a/dxguidedesign/guide_search.py
+++ b/dxguidedesign/guide_search.py
@@ -263,14 +263,6 @@ class GuideSearcher:
                 p = self._construct_guide_memoized(pos, seqs_to_consider,
                     num_needed)
 
-            if p is not None and self.guide_is_suitable_fn is not None:
-                # Verify that the guide is suitable according to the given
-                # function (it should be, in order to have been output
-                # by self.aln.construct_guide(..))
-                gd, _ = p
-                if not self.guide_is_suitable_fn(gd):
-                    p = None
-
             if p is None:
                 # There is no suitable guide at pos
                 if max_guide_cover is None:


### PR DESCRIPTION
This makes several small changes that can have a significant impact on reducing runtime and memory usage for differential identification.