### PR TITLE
Memoize specificity results for each guide

### DIFF
--- a/bin/design.py
+++ b/bin/design.py
@@ -367,6 +367,7 @@ def design_for_id(args):
         required_guides_for_aln = required_guides[i]
         blacklisted_ranges_for_aln = blacklisted_ranges[i]
         alns_in_same_taxon = aln_with_taxid[taxid]
+        memoized_specificity_results = {}
 
         def guide_is_suitable(guide):
             # Return True iff the guide does not contain a blacklisted
@@ -380,8 +381,13 @@ def design_for_id(args):
             # Return True if guide does not hit too many sequences in
             # alignments other than aln
             if aq is not None:
-                return aq.guide_is_specific_to_alns(
-                    guide, alns_in_same_taxon, args.diff_id_frac)
+                if guide in memoized_specificity_results:
+                    return memoized_specificity_results[guide]
+                else:
+                    is_spec = aq.guide_is_specific_to_alns(
+                        guide, alns_in_same_taxon, args.diff_id_frac)
+                    memoized_specificity_results[guide] = is_spec
+                    return is_spec
             else:
                 return True
 


### PR DESCRIPTION
This is a quick change, directly in `design.py`, that can considerably improve runtime (at the expense of memory).