### PR TITLE
Resolve curation edge cases for 4 viral species

### DIFF
--- a/adapt/prepare/prepare_alignment.py
+++ b/adapt/prepare/prepare_alignment.py
@@ -212,10 +212,22 @@ def prepare_for(taxid, segment, ref_accs, out,
                 "during curation for tax %d (segment: %s) using references %s") %
                 (frac_filtered, taxid, segment, ref_accs))
 
-        # Check if there are no sequences left; if that's the case, don't
-        # proceed
+        # Check if there are no sequences left; if that's the case, warn
+        # and try just a reference sequence
         if len(seqs_unaligned_curated) == 0:
-            raise Exception("No sequences remain after curation")
+            # Find a reference genome that was downloaded
+            ref_accver_used = None
+            for accver, seq in seqs_unaligned.items():
+                if accver.split('.')[0] in ref_accs:
+                    seqs_unaligned_curated[accver] = seq
+                    ref_accver_used = accver
+                    break
+            if len(seqs_unaligned_curated) > 0:
+                logger.critical(("No sequences remained after curation, so "
+                    "proceeding with design from a single reference sequence "
+                    "(%s)") % (ref_accver_used))
+            else:
+                raise Exception("No sequences are available for design")
 
     # Produce clusters of unaligned sequences
     logger.info(("Clustering %d sequences"), len(seqs_unaligned_curated))


### PR DESCRIPTION
4 of the ~1,900 known vertebrate-infecting viral species fail the curation/preparation process.

- 1 fails because the genome is too short. This PR decreases the threshold on the minimum allowed genome length. [3154153]
- 3 fail because none of their genome neighbors pass curation. This PR resorts to using a single RefSeq genome as input to design when this is the case. [181473d]

The commit messages give more detail and an example for each case.