### PR TITLE
Automatically get reference sequences; sub-species specificity

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ See [Output](#output) above for a description of this file.
 ADAPT can automatically download and curate sequences during design, and search efficiently over the space of genomic regions to find primers/amplicons as well as guides.
 For example:
 ```bash
-design.py complete-targets auto-from-args 64320 None guides.tsv -gl 28 --obj minimize-guides -gm 1 -gp 0.95 -pl 30 -pm 2 -pp 0.95 --ref-accs NC_035889 --predict-activity-model-path models/classify/model-51373185 models/regress/model-f8b6fd5d --best-n-targets 10 --mafft-path MAFFT_PATH --sample-seqs 100
+design.py complete-targets auto-from-args 64320 None guides.tsv -gl 28 --obj minimize-guides -gm 1 -gp 0.95 -pl 30 -pm 2 -pp 0.95 --auto-refs --predict-activity-model-path models/classify/model-51373185 models/regress/model-f8b6fd5d --best-n-targets 10 --mafft-path MAFFT_PATH --sample-seqs 100
 ```
 downloads and designs against genomes of Zika virus (NCBI taxonomy ID [64320](https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=64320)).
 You must fill in `MAFFT_PATH` with an executable.

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Allow for up to ID_M mismatches when determining whether a guide hits a sequence
 ADAPT does not output guides that hit group/taxons other than the one for which they are being designed.
 Higher values of ID_M and lower values of ID_FRAC correspond to more specificity.
 (Default: 2 for ID_M, 0.05 for ID_FRAC.)
+* `--ref-accs`: Curate sequences based on the sequence identified by this accession number
 * `--specific-against-fastas [fasta] [fasta ...]`: Design guides to be specific against the provided sequences (in FASTA format; do not need to be aligned).
 That is, the guides should not hit sequences in these FASTA files, as measured by ID_M and ID_FRAC.
 * `--specific-against-taxa SPECIFIC_TSV`: Design guides to be specific against the provided taxa.
@@ -312,7 +313,7 @@ See [Output](#output) above for a description of this file.
 ADAPT can automatically download and curate sequences during design, and search efficiently over the space of genomic regions to find primers/amplicons as well as guides.
 For example:
 ```bash
-design.py complete-targets auto-from-args 64320 None NC_035889 guides.tsv -gl 28 --obj minimize-guides -gm 1 -gp 0.95 -pl 30 -pm 2 -pp 0.95 --predict-activity-model-path models/classify/model-51373185 models/regress/model-f8b6fd5d --best-n-targets 10 --mafft-path MAFFT_PATH --sample-seqs 100
+design.py complete-targets auto-from-args 64320 None guides.tsv -gl 28 --obj minimize-guides -gm 1 -gp 0.95 -pl 30 -pm 2 -pp 0.95 --ref-accs NC_035889 --predict-activity-model-path models/classify/model-51373185 models/regress/model-f8b6fd5d --best-n-targets 10 --mafft-path MAFFT_PATH --sample-seqs 100
 ```
 downloads and designs against genomes of Zika virus (NCBI taxonomy ID [64320](https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=64320)).
 You must fill in `MAFFT_PATH` with an executable.

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Allow for up to ID_M mismatches when determining whether a guide hits a sequence
 ADAPT does not output guides that hit group/taxons other than the one for which they are being designed.
 Higher values of ID_M and lower values of ID_FRAC correspond to more specificity.
 (Default: 2 for ID_M, 0.05 for ID_FRAC.)
-* `--ref-accs`: Curate sequences based on the sequence identified by this accession number
+* `--ref-accs`: Curate sequences based on the sequence(s) identified by this accession number(s)
 * `--specific-against-fastas [fasta] [fasta ...]`: Design guides to be specific against the provided sequences (in FASTA format; do not need to be aligned).
 That is, the guides should not hit sequences in these FASTA files, as measured by ID_M and ID_FRAC.
 * `--specific-against-taxa SPECIFIC_TSV`: Design guides to be specific against the provided taxa.

--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ Allow for up to ID_M mismatches when determining whether a guide hits a sequence
 ADAPT does not output guides that hit group/taxons other than the one for which they are being designed.
 Higher values of ID_M and lower values of ID_FRAC correspond to more specificity.
 (Default: 2 for ID_M, 0.05 for ID_FRAC.)
-* `--ref-accs`: Curate sequences based on the sequence(s) identified by this accession number(s)
+* `--auto-refs`: Automatically determine NCBI reference sequences for curation.
+* `--ref-accs [accession] [accession ...]`: Curate sequences using the reference sequence(s) identified by this NCBI GenBank accession number(s).
+This is required if `--auto-refs` is not set.
 * `--specific-against-fastas [fasta] [fasta ...]`: Design guides to be specific against the provided sequences (in FASTA format; do not need to be aligned).
 That is, the guides should not hit sequences in these FASTA files, as measured by ID_M and ID_FRAC.
 * `--specific-against-taxa SPECIFIC_TSV`: Design guides to be specific against the provided taxa.

--- a/README.md
+++ b/README.md
@@ -332,9 +332,6 @@ It fetches and curates genomes, clusters and aligns them, and uses the generated
 
 Below are key arguments to [`design.py`](./bin/design.py) when SEARCH-TYPE is `auto-from-file` or `auto-from-args`:
 
-* `--auto-refs`: Automatically determine NCBI reference sequences to use for curating genomes.
-* `--ref-accs [accession] [accession ...]`: Curate sequences using the reference sequence(s) identified by this NCBI GenBank accession number(s).
-This is required if `--auto-refs` is not set.
 * `--mafft-path MAFFT_PATH`: Use the [MAFFT](https://mafft.cbrc.jp/alignment/software/) executable at MAFFT_PATH for generating alignments.
 * `--prep-memoize-dir PREP_MEMOIZE_DIR`: Memoize alignments and statistics on these alignments to the directory specified by PREP_MEMOIZE_DIR.
 If repeatedly re-running on the same taxonomies, using this argument can significantly improve runtime across runs.
@@ -467,7 +464,7 @@ It identifies Cas13a guides using a pre-trained predictive model of activity.
 
 Run:
 ```bash
-design.py complete-targets auto-from-args 64320 None guides.tsv -gl 28 --obj maximize-activity -pl 30 -pm 1 -pp 0.95 --predict-activity-model-path models/classify/model-51373185 models/regress/model-f8b6fd5d --best-n-targets 5 --auto-refs --mafft-path MAFFT_PATH --sample-seqs 50 --verbose
+design.py complete-targets auto-from-args 64320 None guides.tsv -gl 28 --obj maximize-activity -pl 30 -pm 1 -pp 0.95 --predict-activity-model-path models/classify/model-51373185 models/regress/model-f8b6fd5d --best-n-targets 5 --mafft-path MAFFT_PATH --sample-seqs 50 --verbose
 ```
 This downloads and designs assays to detect genomes of Zika virus (NCBI taxonomy ID [64320](https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=64320)).
 You must fill in `MAFFT_PATH` with an executable of MAFFT.

--- a/adapt/prepare/ncbi_neighbors.py
+++ b/adapt/prepare/ncbi_neighbors.py
@@ -486,8 +486,12 @@ def construct_references(taxid):
         ls = line.strip()
         if len(ls) == 0:
             continue
-        references += [ls]
+        references.append(ls)
 
+    if len(references) == 0:
+        raise ValueError("Taxonomic ID %d does not have any references in "
+                         "NCBI. Try specifying a reference accession using "
+                         "--ref-accs" %taxid)
     return references
 
 

--- a/adapt/prepare/ncbi_neighbors.py
+++ b/adapt/prepare/ncbi_neighbors.py
@@ -491,22 +491,22 @@ def construct_references(taxid):
     return references
 
 
-def add_metadata_to_neighbors_and_filter(neighbors, meta_filt_in=None, meta_filt_out=None):
+def add_metadata_to_neighbors_and_filter(neighbors, meta_filt=None, meta_filt_against=None):
     """Fetch and add metadata to neighbors.
 
     This only fetches for neighbors that do not have metadata set.
 
     This also filters out neighbors which do not match the filters in 
-    meta_filt_in or match a filter in meta_filt_out. It returns the accession 
-    numbers of the neighbors that are filtered out by meta_filt_out.
+    meta_filt or match a filter in meta_filt_against. It returns the accession 
+    numbers of the neighbors that are filtered out by meta_filt_against.
 
     Args:
         neighbors: collection of Neighbor objects
-        meta_filt_in: list of 2 dictionaries where the keys are any of 'country', 'year',
+        meta_filt: list of 2 dictionaries where the keys are any of 'country', 'year',
             'entry_create_year', 'taxid' and values for the first are a collection 
             of what to include or True to indicate that the metadata must exist and
             the second are what to exclude.
-        meta_filt_out: list of 2 dictionaries where the keys are any of 'country', 'year',
+        meta_filt_against: list of 2 dictionaries where the keys are any of 'country', 'year',
             'entry_create_year', 'taxid' and values for the first are a collection 
             of what to include in accessions to be specific against and
             the second are what to exclude.
@@ -528,24 +528,24 @@ def add_metadata_to_neighbors_and_filter(neighbors, meta_filt_in=None, meta_filt
         if neighbor.acc in to_fetch:
             neighbor.metadata = metadata[neighbor.acc]
 
-        if meta_filt_in:
-            for key, value in meta_filt_in[0].items():
+        if meta_filt:
+            for key, value in meta_filt[0].items():
                 if value is True and neighbor.metadata[key] is None:
                     acc_to_skip.add(neighbor.acc)
                 elif neighbor.metadata[key] not in value:
                     acc_to_skip.add(neighbor.acc)
-            for key, value in meta_filt_in[1].items():
+            for key, value in meta_filt[1].items():
                 if neighbor.metadata[key] in value:
                     acc_to_skip.add(neighbor.acc)
 
-        if meta_filt_out:
-            for key, value in meta_filt_out[0].items():
+        if meta_filt_against:
+            for key, value in meta_filt_against[0].items():
                 if neighbor.metadata[key] in value:
                     if neighbor.acc not in acc_to_skip:
                         acc_to_skip.add(neighbor.acc)
                         out_not_in += 1
                     specific_against_metadata_acc.add(neighbor.acc)
-            for key, value in meta_filt_out[1].items():
+            for key, value in meta_filt_against[1].items():
                 if neighbor.metadata[key] not in value:
                     if neighbor.acc not in acc_to_skip:
                         acc_to_skip.add(neighbor.acc)

--- a/adapt/prepare/ncbi_neighbors.py
+++ b/adapt/prepare/ncbi_neighbors.py
@@ -501,18 +501,19 @@ def add_metadata_to_neighbors_and_filter(neighbors, meta_filt=None, meta_filt_ag
 
     Args:
         neighbors: collection of Neighbor objects
-        meta_filt: list of 2 dictionaries where the keys are any of 'country', 'year',
+        meta_filt: tuple of 2 dictionaries where the keys are any of 'country', 'year',
             'entry_create_year', 'taxid' and values for the first are a collection 
             of what to include or True to indicate that the metadata must exist and
             the second are what to exclude.
-        meta_filt_against: list of 2 dictionaries where the keys are any of 'country', 
+        meta_filt_against: tuple of 2 dictionaries where the keys are any of 'country', 
             'year', 'entry_create_year', 'taxid' and values for the first are a 
             collection of what to include in accessions to be specific against and
             the second are what to exclude.
 
     Returns:
         neighbors with metadata included (excluding the ones filtered out), and
-            accession numbers of neighbors that are filtered out by meta_filt_against
+            accession numbers of neighbors for the design to be specific against 
+            (as specified by meta_filt_against)
     """
     # Fetch metadata for each neighbor without metadata
     to_fetch = set(n.acc for n in neighbors if n.metadata == {})

--- a/adapt/prepare/ncbi_neighbors.py
+++ b/adapt/prepare/ncbi_neighbors.py
@@ -491,7 +491,7 @@ def construct_references(taxid):
     return references
 
 
-def add_metadata_to_neighbors_and_filter(neighbors, filters={}):
+def add_metadata_to_neighbors_and_filter(neighbors, infilter={}, outfilter={}):
     """Fetch and add metadata to neighbors.
 
     This only fetches for neighbors that do not have metadata set.
@@ -501,9 +501,12 @@ def add_metadata_to_neighbors_and_filter(neighbors, filters={}):
 
     Args:
         neighbors: collection of Neighbor objects
-        filters: dictionary where the keys are any of 'country', 'year',
+        infilter: dictionary where the keys are any of 'country', 'year',
             'entry_create_year', 'taxid' and values are a collection of what 
             to include or True to indicate that the metadata must exist
+        outfilter: dictionary where the keys are any of 'country', 'year',
+            'entry_create_year', 'taxid' and values are a collection of what 
+            to exclude
 
     Returns:
         neighbors, with metadata included (excluding the ones filtered out)
@@ -516,14 +519,21 @@ def add_metadata_to_neighbors_and_filter(neighbors, filters={}):
         metadata = {}
     acc_to_skip = set()
     for neighbor in neighbors:
+        skipped = False
         if neighbor.acc in to_fetch:
             neighbor.metadata = metadata[neighbor.acc]
-        for key, value in filters.items():
+        for key, value in infilter.items():
             if value is True:
                 if neighbor.metadata[key] is None:
                     acc_to_skip.add(neighbor.acc)
             elif neighbor.metadata[key] not in value:
                 acc_to_skip.add(neighbor.acc)
+                skipped = True
+        if not skipped:
+            for key, value in outfilter.items():
+                if neighbor.metadata[key] in value:
+                    acc_to_skip.add(neighbor.acc)
+                    skipped = True
 
     # Remove accessions that do not have match the filters
     if len(acc_to_skip) > 0:

--- a/adapt/prepare/ncbi_neighbors.py
+++ b/adapt/prepare/ncbi_neighbors.py
@@ -419,12 +419,11 @@ class Neighbor:
             self._list_of_attrs())
 
 
-def construct_neighbors(taxid, strain_sp = False):
+def construct_neighbors(taxid):
     """Construct Neighbor objects for all neighbors of a taxonomic ID.
 
     Args:
         taxid: taxonomic ID to download neighbors for
-        strain_sp: boolean; True to only get neighbors of the same strain, False otherwise
 
     Returns:
         list of Neighbor objects
@@ -436,7 +435,6 @@ def construct_neighbors(taxid, strain_sp = False):
 
     neighbors = []
     encountered_header = False
-    self_tax_name = None
     for line in fetch_neighbors_table(taxid):
         if len(line.strip()) == 0:
             continue
@@ -446,11 +444,6 @@ def construct_neighbors(taxid, strain_sp = False):
         if line.startswith('##'):
             # Header line
             encountered_header = True
-            if strain_sp:
-                if line.startswith('## Neighbors data for complete genomes: '):
-                    end = line.find(' (taxid')
-                    if end > 40:
-                        self_tax_name = line[40:end]
             if line.startswith('## Columns:'):
                 # Verify the columns are as expected
                 col_names = [n.replace('"', '') for n in ls[1:]]
@@ -473,12 +466,7 @@ def construct_neighbors(taxid, strain_sp = False):
         segment = ls[5].replace('segment', '').strip()
 
         neighbor = Neighbor(acc, refseq_acc, hosts, lineage, tax_name, segment)
-        if self_tax_name is None or self_tax_name == tax_name:
-            neighbors += [neighbor]
-
-    if self_tax_name is None and strain_sp:
-        logger.critical(("The strain could not be identified from the tax "
-            "%d; this may not be the taxonomy ID for a specific strain"), taxid)
+        neighbors += [neighbor]
 
     return neighbors
 

--- a/adapt/prepare/prepare_alignment.py
+++ b/adapt/prepare/prepare_alignment.py
@@ -76,9 +76,14 @@ def prepare_for(taxid, segment, ref_accs, out,
         sequences_to_use: if set, a dict of sequences to use instead of
             fetching them for taxid; note that this does not perform
             curation on these sequences
-        meta_filt: a dictionary of filters of metadata to include in the design
-        meta_filt_against: a dictionary of filters of metadata to exclude from 
-            the design
+        meta_filt: tuple of 2 dictionaries where the keys are any of 'country', 'year',
+            'entry_create_year', 'taxid' and values for the first are a collection 
+            of what to include or True to indicate that the metadata must exist and
+            the second are what to exclude.
+        meta_filt_against: tuple of 2 dictionaries where the keys are any of 'country', 
+            'year', 'entry_create_year', 'taxid' and values for the first are a 
+            collection of what to include in accessions to be specific against and
+            the second are what to exclude.
 
     Returns:
         number of clusters, set of accessions filtered out by meta_filt_against
@@ -342,6 +347,14 @@ def fetch_sequences_for_taxonomy(taxid, segment):
 
 
 def fetch_sequences_for_acc_list(acc_to_fetch):
+    """Fetch list of sequences given a list of accessions
+
+    Args:
+        acc_to_fetch: list of accessions
+
+    Returns:
+        dict mapping sequence header to sequence string
+    """
     seqs_unaligned_fp = ncbi_neighbors.fetch_fastas(acc_to_fetch)
     seqs_unaligned = align.read_unaligned_seqs(seqs_unaligned_fp)
     # Delete temporary file

--- a/adapt/prepare/prepare_alignment.py
+++ b/adapt/prepare/prepare_alignment.py
@@ -112,7 +112,7 @@ def prepare_for(taxid, segment, ref_accs, out,
         if years_tsv is not None:
             # Fetch metadata (including year), add it to neighbors, and
             # filter out ones without a known year
-            neighbors = ncbi_neighbors.add_metadata_to_neighbors_and_filter(neighbors)
+            neighbors = ncbi_neighbors.add_metadata_to_neighbors_and_filter(neighbors, {'year': True})
 
         if len(neighbors) == 0:
             if segment != None and segment != '':

--- a/adapt/prepare/prepare_alignment.py
+++ b/adapt/prepare/prepare_alignment.py
@@ -24,7 +24,7 @@ def prepare_for(taxid, segment, ref_accs, out,
         sample_seqs=None, filter_warn=0.25, min_seq_len=150,
         min_cluster_size=2, prep_influenza=False, years_tsv=None,
         cluster_threshold=0.1, accessions_to_use=None,
-        sequences_to_use=None):
+        sequences_to_use=None, filters=None):
     """Prepare an alignment for a taxonomy.
 
     This does the following:
@@ -76,6 +76,9 @@ def prepare_for(taxid, segment, ref_accs, out,
         sequences_to_use: if set, a dict of sequences to use instead of
             fetching them for taxid; note that this does not perform
             curation on these sequences
+        filters: a list of two dictionaries, the first filters of metadata to
+            include in the design, the second filters of metadata to exclude from 
+            the design
 
     Returns:
         number of clusters
@@ -109,7 +112,13 @@ def prepare_for(taxid, segment, ref_accs, out,
         logger.info(("There are %d neighbors (%d with unique accessions)"),
                 len(neighbors), num_unique_acc)
 
-        if years_tsv is not None:
+        # Filter neighbors by include/exclude filters
+        if filters:
+            if 'year' not in filters[0] and years_tsv is not None:
+                filters[0]['year'] = True
+            neighbors = ncbi_neighbors.add_metadata_to_neighbors_and_filter(neighbors, filters[0], filters[1])
+
+        elif years_tsv is not None:
             # Fetch metadata (including year), add it to neighbors, and
             # filter out ones without a known year
             neighbors = ncbi_neighbors.add_metadata_to_neighbors_and_filter(neighbors, {'year': True})

--- a/adapt/prepare/tests/test_ncbi_neighbors.py
+++ b/adapt/prepare/tests/test_ncbi_neighbors.py
@@ -18,6 +18,12 @@ class TestURLConstruction(unittest.TestCase):
             '.cgi?taxid=123&cmd=download2')
         self.assertEqual(url, expected_url)
 
+    def test_ncbi_reference_url(self):
+        url = nn.ncbi_reference_url(123)
+        expected_url = ('https://www.ncbi.nlm.nih.gov/genomes/GenomesGroup'
+            '.cgi?taxid=123&cmd=download1')
+        self.assertEqual(url, expected_url)
+
     def test_ncbi_fasta_download_url(self):
         url = nn.ncbi_fasta_download_url(['A123', 'A456', 'B789'])
         expected_url = ('https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch'
@@ -33,7 +39,7 @@ class TestURLConstruction(unittest.TestCase):
     def test_read_taxid(self):
         url = ('https://www.ncbi.nlm.nih.gov/genomes/GenomesGroup'
             '.cgi?taxid=123&cmd=download2')
-        taxid = nn.read_taxid_from_ncbi_neighbors_url(url)
+        taxid = nn.read_taxid_from_ncbi_url(url)
         expected_taxid = 123
         self.assertEqual(taxid, expected_taxid)
 
@@ -42,7 +48,7 @@ class TestConstructNeighbors(unittest.TestCase):
     """Tests the construct_neighbors() function.
 
     The function construct_neighbors() calls fetch_neighbors_table(),
-    which makes a request to NCBI. To avoid the request, thsi overrides
+    which makes a request to NCBI. To avoid the request, this overrides
     fetch_neighbors_table() to return a known neighbors table.
     """
 

--- a/adapt/utils/seq_io.py
+++ b/adapt/utils/seq_io.py
@@ -262,7 +262,7 @@ def read_taxonomies(fn):
             if segment.lower() == 'none':
                 segment = None
             ref_accs = ls[3].split(',')
-            taxs += [(label, tax_id, segment, ref_accs)]
+            taxs += [(label, tax_id, segment, ref_accs, None, None)]
     return taxs
 
 
@@ -412,4 +412,31 @@ def read_taxonomy_specificity_ignore(fn):
 
             tax_ignore[tax_id_a].add(tax_id_b)
     return tax_ignore
+
+
+def read_filters(filters):
+    """Create dictionary of filters from a list.
+    
+    Args:
+        filters: list of filters in the format 'key=value,value' with an
+            arbitrary number of values
+
+    Returns:
+        dict where each key is any of ['taxid', 'year', 'country'] 
+            and each value is a list
+    """
+    dict_filters = {}
+    for filt in filters:
+        filt_split = filt.split('=')
+        if len(filt_split) != 2:
+            raise Exception("Incorrect format for include filter '%s'; should be "
+                "'metadata=value'" %filt)
+        if filt_split[0] not in ['taxid', 'year', 'country']:
+            raise Exception("Incorrect include filter key '%s'; should be one of "
+                "['taxid', 'year', 'country']" %filt_split[0])
+        if filt_split[0] in ['taxid', 'year']:
+            dict_filters[filt_split[0]] = [int(i) for i in filt_split[1].split(",")]
+        else:
+            dict_filters[filt_split[0]] = filt_split[1].split(",")
+    return dict_filters
 

--- a/adapt/utils/seq_io.py
+++ b/adapt/utils/seq_io.py
@@ -422,21 +422,27 @@ def read_filters(filters):
             arbitrary number of values
 
     Returns:
-        dict where each key is any of ['taxid', 'year', 'country'] 
-            and each value is a list
+        list of 2 dicts where each key is any of ['taxid', 'year', 'country']
+            and each value is what to include for the first dict and exclude for
+            the second dict
     """
-    dict_filters = {}
+    dict_filters = [{}, {}]
     for filt in filters:
-        filt_split = filt.split('=')
+        dict_to_use = 0
+        filt_split = filt.split('!=')
+        if len(filt_split) == 2:
+            dict_to_use = 1
+        else:
+            filt_split = filt.split('=')
         if len(filt_split) != 2:
-            raise Exception("Incorrect format for include filter '%s'; should be "
-                "'metadata=value'" %filt)
+            raise Exception("Incorrect format for filter '%s'; should be "
+                "'metadata=value or metadata!=value'" %filt)
         if filt_split[0] not in ['taxid', 'year', 'country']:
-            raise Exception("Incorrect include filter key '%s'; should be one of "
+            raise Exception("Incorrect filter key '%s'; should be one of "
                 "['taxid', 'year', 'country']" %filt_split[0])
         if filt_split[0] in ['taxid', 'year']:
-            dict_filters[filt_split[0]] = [int(i) for i in filt_split[1].split(",")]
+            dict_filters[dict_to_use][filt_split[0]] = [int(i) for i in filt_split[1].split(",")]
         else:
-            dict_filters[filt_split[0]] = filt_split[1].split(",")
+            dict_filters[dict_to_use][filt_split[0]] = filt_split[1].split(",")
     return dict_filters
 

--- a/adapt/utils/seq_io.py
+++ b/adapt/utils/seq_io.py
@@ -445,13 +445,16 @@ def read_metadata_filters(meta_filts):
             'key!=values' with a comma separated list of values
 
     Returns:
-        list of 2 dicts where each key is any of ['taxid', 'year', 'country']
+        tuple of 2 dicts where each key is any of ['taxid', 'year', 'country']
             and each value is what to include for the first dict and exclude for
             the second dict
     """
     dict_filter_eq = {}
     dict_filter_neq = {}
     for filt in meta_filts:
+        if ' ' in filt:
+            raise ValueError("Incorrect format for filter '%s'; individual filters "
+                "should not include spaces" %filt)
         dict_to_use = dict_filter_eq
         filt_split = filt.split('!=')
         if len(filt_split) == 2:
@@ -459,10 +462,10 @@ def read_metadata_filters(meta_filts):
         else:
             filt_split = filt.split('=')
         if len(filt_split) != 2:
-            raise Exception("Incorrect format for filter '%s'; should be "
+            raise ValueError("Incorrect format for filter '%s'; should be "
                 "'metadata=value or metadata!=value'" %filt)
         if filt_split[0] not in ['taxid', 'year', 'country']:
-            raise Exception("Incorrect filter key '%s'; should be one of "
+            raise ValueError("Incorrect filter key '%s'; should be one of "
                 "['taxid', 'year', 'country']" %filt_split[0])
         if filt_split[0] in ['taxid', 'year']:
             dict_to_use[filt_split[0]] = [int(i) for i in filt_split[1].split(",")]

--- a/adapt/utils/seq_io.py
+++ b/adapt/utils/seq_io.py
@@ -414,11 +414,11 @@ def read_taxonomy_specificity_ignore(fn):
     return tax_ignore
 
 
-def read_filters(filters):
-    """Create dictionary of filters from a list.
+def read_metadata_filters(meta_filts):
+    """Create dictionaries of metadata filters from a list.
     
     Args:
-        filters: list of filters in the format 'key=value,value' with an
+        meta_filts: list of filters in the format 'key=value,value' with an
             arbitrary number of values
 
     Returns:
@@ -427,7 +427,7 @@ def read_filters(filters):
             the second dict
     """
     dict_filters = [{}, {}]
-    for filt in filters:
+    for filt in meta_filts:
         dict_to_use = 0
         filt_split = filt.split('!=')
         if len(filt_split) == 2:

--- a/adapt/utils/seq_io.py
+++ b/adapt/utils/seq_io.py
@@ -237,6 +237,7 @@ def read_taxonomies(fn):
                     commas to separate values, semicolons to separate filters
 
         6) (optional) metadata filters to exclude from a taxa and be specific against,
+            column 5 must be included to include this column,
             format: 'metadata=value' or 'metadata!=value', 
                     commas to separate values, semicolons to separate filters
 
@@ -254,7 +255,7 @@ def read_taxonomies(fn):
             ls = line.rstrip().split('\t')
             if len(ls) < 4 or len(ls) > 6:
                 raise Exception(("Input taxonomy TSV must have between 4 and 6 columns"))
-            print(ls)
+
             label = ls[0]
             if label in labels:
                 raise Exception(("Taxonomy label '%s' is not unique") % label)
@@ -273,11 +274,11 @@ def read_taxonomies(fn):
 
             meta_filt = None
             if len(ls) > 4 and ls[4].lower() not in none_strings:
-                meta_filt = seq_io.read_metadata_filters(ls[4].split(';'))
+                meta_filt = read_metadata_filters(ls[4].split(';'))
 
             meta_filt_against = None
             if len(ls) > 5 and ls[5].lower() not in none_strings:
-                meta_filt_against = seq_io.read_metadata_filters(ls[5].split(';'))
+                meta_filt_against = read_metadata_filters(ls[5].split(';'))
 
             taxs += [(label, tax_id, segment, ref_accs, meta_filt, meta_filt_against)]
     return taxs

--- a/bin/design.py
+++ b/bin/design.py
@@ -272,7 +272,8 @@ def prepare_alignments(args):
     # Read list of taxonomies
     if args.input_type == 'auto-from-args':
         s = None if args.segment == 'None' else args.segment
-        ref_accs = args.ref_accs.split(',')
+        ref_accs = ncbi_neighbors.construct_references(args.tax_id) \
+            if args.auto_refs else args.ref_accs.split(',')
         taxs = [(None, args.tax_id, s, ref_accs)]
     elif args.input_type == 'auto-from-file':
         taxs = seq_io.read_taxonomies(args.in_tsv)
@@ -1221,12 +1222,15 @@ if __name__ == "__main__":
     input_autoargs_subparser.add_argument('segment',
         help=("Label of segment (e.g., 'S') if there is one, or 'None' if "
               "unsegmented"))
-    input_autoargs_subparser.add_argument('ref_accs',
-        help=("Accessions of reference sequences to use for curation (comma-"
-              "separated)"))
     input_autoargs_subparser.add_argument('out_tsv',
         help=("Path to output TSVs, with one per cluster; output TSVs are "
               "OUT_TSV.{cluster-number}"))
+    input_autoargs_subparser.add_argument('--auto-refs', action='store_true',
+        help=("If set, automatically get accession numbers for "
+              "reference sequences from NCBI"))
+    input_autoargs_subparser.add_argument('--ref-accs',
+        help=("Accessions of reference sequences to use for curation (comma-"
+              "separated). Required if AUTO_REFS is not set"))
     input_autoargs_subparser.add_argument('--write-input-seqs',
         help=("Path to a file to which to write the sequences "
               "(accession.version) being used as input for design"))

--- a/bin/design.py
+++ b/bin/design.py
@@ -764,6 +764,7 @@ def main(args):
                 "FASTAs"))
         args.design_for = None
         args.taxid_for_fasta = list(range(len(args.in_fasta)))
+        args.specific_against_metadata_accs = [[] for _ in range(len(args.in_fasta))]
     else:
         raise Exception("Unknown input type subcommand '%s'" % args.input_type)
 

--- a/bin/design.py
+++ b/bin/design.py
@@ -275,7 +275,7 @@ def prepare_alignments(args):
     if args.input_type == 'auto-from-args':
         s = None if args.segment == 'None' else args.segment
         ref_accs = ncbi_neighbors.construct_references(args.tax_id) \
-            if args.auto_refs else args.ref_accs
+            if not args.ref_accs else args.ref_accs
         meta_filt = None
         meta_filt_against = None
         if args.metadata_filter:
@@ -569,6 +569,8 @@ def design_for_id(args):
         required_guides_for_aln = required_guides[i]
         blacklisted_ranges_for_aln = blacklisted_ranges[i]
         alns_in_same_taxon = aln_with_taxid[taxid]
+        # For metadata filtering, we only want to be specific against the 
+        # accessions in alns[specific_against_metadata_index]
         specific_against_metadata_index = specific_against_metadata_indices[i] \
             if i in specific_against_metadata_indices else None
 
@@ -1287,23 +1289,23 @@ if __name__ == "__main__":
     input_autoargs_subparser.add_argument('out_tsv',
         help=("Path to output TSVs, with one per cluster; output TSVs are "
               "OUT_TSV.{cluster-number}"))
-    input_autoargs_subparser.add_argument('--auto-refs', action='store_true',
-        help=("If set, automatically get accession numbers for "
-              "reference sequences from NCBI"))
     input_autoargs_subparser.add_argument('--ref-accs', nargs='+',
         help=("Accession(s) of reference sequence(s) to use for curation (comma-"
-              "separated). Required if AUTO_REFS is not set"))
+              "separated). If not set, ADAPT will automatically get accessions "
+              "for reference sequences from NCBI based on the taxonomic ID"))
     input_autoargs_subparser.add_argument('--metadata-filter', nargs='+',
         help=("Only include accessions of specified taxonomic ID that match this metadata "
             "in the design. Metadata options are year, taxid, and country. Format as "
             "'metadata=value' or 'metadata!=value'. Separate multiple values with commas "
-            "and different metadata filters with spaces (e.g. 'year!=2020,2019 taxid=11060')"))
+            "and different metadata filters with spaces (e.g. '--metadata-filter "
+            "year!=2020,2019 taxid=11060')"))
     input_autoargs_subparser.add_argument('--specific-against-metadata-filter', nargs='+',
         help=("Only include accessions of the specified taxonomic ID that do not match this "
             "metadata in the design, and be specific against any accession that does match "
             "this metadata. Metadata options are year, taxid, and country. Format as "
             "'metadata=value' or 'metadata!=value'. Separate multiple values with commas "
-            "and different metadata filters with spaces (e.g. 'year!=2020,2019 taxid=11060')"))
+            "and different metadata filters with spaces (e.g. "
+            "'--specific-against-metadata-filter year!=2020,2019 taxid=11060')"))
     input_autoargs_subparser.add_argument('--write-input-seqs',
         help=("Path to a file to which to write the sequences "
               "(accession.version) being used as input for design"))

--- a/bin/tests/test_design.py
+++ b/bin/tests/test_design.py
@@ -113,7 +113,7 @@ class TestDesign(object):
             if input_type == 'fasta':
                 argv.extend([input_file, '-o', output_loc])
             elif input_type == 'auto-from-args':
-                argv.extend(['64320', 'None', 'NC_035889', output_loc])
+                argv.extend(['64320', 'None', output_loc])
             elif input_type == 'auto-from-file':
                 argv.extend([input_file, output_loc])
 
@@ -291,7 +291,8 @@ class TestDesignFull(TestDesign.TestDesignCase):
         self.curate_against_ref = align.curate_against_ref
 
         def small_curate(seqs, ref_accs, asm=None, remove_ref_accs=[]):
-            return {seq: seqs[seq] for seq in seqs if seq.split('.')[0] != 'NC_035889'}
+            return {seq: seqs[seq] for seq in seqs \
+                if seq.split('.')[0] not in remove_ref_accs}
 
         align.curate_against_ref = small_curate
 


### PR DESCRIPTION
Automatically get references for sequences from NCBI's database by default; allow reference sequences to be manually supplied using `--ref-accs`. Changes the default arguments of auto-args to not require a reference sequence if `--auto-refs` is specified. Also, add sub-species specificity based on metadata using `--metadata-filter` and `--specific-against-metadata-filter`. `--metadata-filter` determines what accessions within a taxa to include; `--specific-against-metadata-filter` determines what accessions within a taxa to design to be specific against.