### PR TITLE
Integration tests

### DIFF
--- a/adapt/guide_search.py
+++ b/adapt/guide_search.py
@@ -245,8 +245,7 @@ class GuideSearcher:
 
         # Decide whether to resize
         total_size = sum(len(self._memoized_guides[k])
-                for k in self._memoized_guides.keys()) + \
-                self._memoized_guides_num_removed_since_last_resize
+                for k in self._memoized_guides.keys())
         if total_size > 0:
             frac_removed = float(self._memoized_guides_num_removed_since_last_resize) / total_size
             logger.debug(("Deciding to resize with a fraction %f removed "

--- a/adapt/guide_search.py
+++ b/adapt/guide_search.py
@@ -938,7 +938,7 @@ class GuideSearcherMinimizeGuides(GuideSearcher):
         logger.debug("Adding required covers to cover")
         for gd, gd_pos in self.required_guides.items():
             if (gd_pos < start or
-                    gd_pos + self.guide_length > end):
+                    gd_pos + self.guide_length >= end):
                 # gd is not fully within this window
                 continue
             # Find the sequences in the alignment that are bound by gd

--- a/adapt/guide_search.py
+++ b/adapt/guide_search.py
@@ -245,7 +245,8 @@ class GuideSearcher:
 
         # Decide whether to resize
         total_size = sum(len(self._memoized_guides[k])
-                for k in self._memoized_guides.keys())
+                for k in self._memoized_guides.keys()) + \
+                self._memoized_guides_num_removed_since_last_resize
         if total_size > 0:
             frac_removed = float(self._memoized_guides_num_removed_since_last_resize) / total_size
             logger.debug(("Deciding to resize with a fraction %f removed "
@@ -938,7 +939,7 @@ class GuideSearcherMinimizeGuides(GuideSearcher):
         logger.debug("Adding required covers to cover")
         for gd, gd_pos in self.required_guides.items():
             if (gd_pos < start or
-                    gd_pos + self.guide_length >= end):
+                    gd_pos + self.guide_length > end):
                 # gd is not fully within this window
                 continue
             # Find the sequences in the alignment that are bound by gd

--- a/adapt/prepare/align.py
+++ b/adapt/prepare/align.py
@@ -301,7 +301,7 @@ def set_mafft_exec(mafft_path):
     global _mafft_exec
     # Verify the path exists and is an executable
     if not os.path.isfile(mafft_path) or not os.access(mafft_path, os.X_OK):
-        raise Exception(("Path to mafft (%s) does not exist or is not "
+        raise FileNotFoundError(("Path to mafft (%s) does not exist or is not "
             "executable") % mafft_path)
     _mafft_exec = mafft_path
 

--- a/adapt/prepare/prepare_alignment.py
+++ b/adapt/prepare/prepare_alignment.py
@@ -206,8 +206,10 @@ def prepare_for(taxid, segment, ref_accs, out,
                 len(seqs_unaligned_curated))
 
         # When determining how many were filtered out, we care about acc_to_fetch
-        # (which has multiplicity in case of sampling with replacement)
-        frac_filtered = 1.0 - float(len(seqs_unaligned_curated)) / len(acc_to_fetch)
+        # (which has multiplicity in case of sampling with replacement) minus any
+        # removed reference sequences
+        frac_filtered = 1.0 - float(len(seqs_unaligned_curated)) / \
+                (len(acc_to_fetch) - len(added_ref_accs_to_fetch))
         if frac_filtered >= filter_warn:
             logger.warning(("A fraction %f of sequences were filtered out "
                 "during curation for tax %d (segment: %s) using references %s") %

--- a/adapt/prepare/tests/test_ncbi_neighbors.py
+++ b/adapt/prepare/tests/test_ncbi_neighbors.py
@@ -42,7 +42,7 @@ class TestConstructNeighbors(unittest.TestCase):
     """Tests the construct_neighbors() function.
 
     The function construct_neighbors() calls fetch_neighbors_table(),
-    which makes a request to NCBI. To avoid the request, thsi overrides
+    which makes a request to NCBI. To avoid the request, this overrides
     fetch_neighbors_table() to return a known neighbors table.
     """
 

--- a/adapt/tests/test_alignment.py
+++ b/adapt/tests/test_alignment.py
@@ -595,6 +595,7 @@ class TestAlignment(unittest.TestCase):
                   [1/3.0, 1/3.0, 1/3.0], 
                   [1/3.0, 1/3.0, 1/3.0], 
                   [0.25, 0.25, 0.25, 0.25]]
+
         entropy = [sum([-p*log2(p) for p in ps]) for ps in all_ps]
         self.assertEqual(aln.position_entropy(),
                          entropy)

--- a/bin/design.py
+++ b/bin/design.py
@@ -50,6 +50,7 @@ OBJ_PARAM_DEFAULTS = {
             'guide_cover_frac': 1.0
         },
         'maximize-activity': {
+            'guide_mismatches': 0,
             'soft_guide_constraint': 1,
             'hard_guide_constraint': 5,
             'penalty_strength': 0.25,
@@ -642,10 +643,12 @@ def design_for_id(args):
         if args.search_cmd == 'sliding-window':
             # Find an optimal set of guides for each window in the genome,
             # and write them to a file
+            print_analysis = not args.quiet_analysis
             gs.find_guides_with_sliding_window(args.window_size,
                 args.out_tsv[i],
                 window_step=args.window_step,
-                sort=args.sort_out)
+                sort=args.sort_out,
+                print_analysis=print_analysis)
         elif args.search_cmd == 'complete-targets':
             # Find optimal targets (primer and guide set combinations),
             # and write them to a file
@@ -681,7 +684,7 @@ def design_for_id(args):
             aq.unmask_all_aln()
 
 
-def main(args):
+def run(args):
     logger = logging.getLogger(__name__)
 
     # Set random seed for entire program
@@ -736,7 +739,7 @@ def main(args):
             years_tsv.close()
 
 
-if __name__ == "__main__":
+def argv_to_args(argv):
     parser = argparse.ArgumentParser()
 
     ###########################################################################
@@ -1036,6 +1039,9 @@ if __name__ == "__main__":
         help=("If set, sort output TSV by number of guides "
               "(ascending) then by score (descending); "
               "default is to sort by window position"))
+    parser_sw_args.add_argument('--quiet-analysis', action='store_true',
+        help=("If set, do not print analysis information "
+              "to output"))
 
     # Subcommand: complete-targets
     parser_ct = search_subparsers.add_parser('complete-targets',
@@ -1274,14 +1280,14 @@ if __name__ == "__main__":
                   "taxonomy is provided as command-line arguments."))
     ###########################################################################
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv[1:])
 
     # Handle missing positional arguments by printing a help message
-    if len(sys.argv) == 1:
+    if len(argv) == 1:
         # No arguments
         parser.print_help()
         sys.exit(1)
-    if len(sys.argv) == 2:
+    if len(argv) == 2:
         # Only one position argument (missing input type)
         if args.search_cmd == 'sliding-window':
             parser_sw.print_help()
@@ -1292,4 +1298,8 @@ if __name__ == "__main__":
     # Setup the logger
     log.configure_logging(args.log_level)
 
-    main(args)
+    return args
+
+
+if __name__ == "__main__":
+    run(argv_to_args(sys.argv))

--- a/bin/design.py
+++ b/bin/design.py
@@ -643,12 +643,11 @@ def design_for_id(args):
         if args.search_cmd == 'sliding-window':
             # Find an optimal set of guides for each window in the genome,
             # and write them to a file
-            print_analysis = not args.quiet_analysis
             gs.find_guides_with_sliding_window(args.window_size,
                 args.out_tsv[i],
                 window_step=args.window_step,
                 sort=args.sort_out,
-                print_analysis=print_analysis)
+                print_analysis=(args.log_level==logging.INFO))
         elif args.search_cmd == 'complete-targets':
             # Find optimal targets (primer and guide set combinations),
             # and write them to a file
@@ -1039,9 +1038,6 @@ def argv_to_args(argv):
         help=("If set, sort output TSV by number of guides "
               "(ascending) then by score (descending); "
               "default is to sort by window position"))
-    parser_sw_args.add_argument('--quiet-analysis', action='store_true',
-        help=("If set, do not print analysis information "
-              "to output"))
 
     # Subcommand: complete-targets
     parser_ct = search_subparsers.add_parser('complete-targets',

--- a/bin/tests/test_design.py
+++ b/bin/tests/test_design.py
@@ -1,0 +1,150 @@
+"""Tests for design_naively.py
+"""
+
+import random
+import os
+import copy
+import tempfile
+import unittest
+
+from collections import OrderedDict
+from argparse import Namespace
+from adapt import alignment
+from adapt.utils import seq_io
+from bin import design
+
+__author__ = 'Priya Pillai <ppillai@broadinstitute.org>'
+
+
+class TestDesignFasta(unittest.TestCase):
+    """Test design.py
+    """
+
+    def setUp(self):
+        # Create a temporary fasta file
+        self.fasta = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        # Closes the file so that it can be reopened on Windows
+        self.fasta.close()
+
+        self.seqs = OrderedDict()
+        # self.seqs["genome_1"] = "AACCA"
+        # self.seqs["genome_2"] = "AAATA"
+        # self.seqs["genome_3"] = "GGATA"
+        # self.seqs["genome_4"] = "GGGAA"
+        self.seqs["genome_1"] = "AACTA-"
+        self.seqs["genome_2"] = "AAACT-"
+        self.seqs["genome_3"] = "GGCTA-"
+        self.seqs["genome_4"] = "GGCTT-"
+
+        seq_io.write_fasta(self.seqs, self.fasta.name)
+
+        # Create a temporary output file 
+        self.output = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        self.output.close()
+
+        self.files = [self.fasta.name, self.output.name]
+
+    def check_results(self, file, expected):
+        with open(file) as f:
+            for i, line in enumerate(f):
+                self.assertLess(i, len(expected))
+                self.assertEqual(line, expected[i])
+            self.assertEqual(i, len(expected)-1)
+
+    def test_min_guides(self):
+        argv = baseArgv(input_file=self.fasta.name, output_file=self.output.name)
+        args = design.argv_to_args(argv)
+        design.run(args)
+        expected = ["window-start\twindow-end\tcount\tscore\ttotal-frac-bound"
+                    "\ttarget-sequences\ttarget-sequence-positions\n",
+                    "0\t3\t1\t1.0\t1.0\tAA\t{0}\n",
+                    "1\t4\t1\t1.0\t0.75\tCT\t{2}\n",
+                    "2\t5\t1\t1.0\t0.75\tCT\t{2}\n"]
+        self.check_results(self.output.name, expected)
+
+    def test_max_activity(self):
+        argv = baseArgv(objective='maximize-activity', input_file=self.fasta.name, 
+                        output_file=self.output.name)
+        args = design.argv_to_args(argv)
+        design.run(args)
+        expected = ["window-start\twindow-end\tcount\tobjective-value\ttotal-frac-bound"
+                    "\tguide-set-expected-activity\tguide-set-median-activity"
+                    "\tguide-set-5th-pctile-activity\tguide-expected-activities"
+                    "\ttarget-sequences\ttarget-sequence-positions\n",
+                    "0\t3\t1\t1.0\t1.0\t1.0\t1.0\t1.0\t1.0\tAA\t{0}\n",
+                    "1\t4\t1\t1.0\t1.0\t1.0\t1.0\t1.0\t1.0\tAC\t{2}\n",
+                    "2\t5\t1\t1.0\t1.0\t1.0\t1.0\t1.0\t1.0\tCT\t{3}\n"]
+        self.check_results(self.output.name, expected)
+
+    def test_complete_targets(self):
+        argv = baseArgv(search_type='complete-targets', input_file=self.fasta.name, 
+                        output_file=self.output.name)
+        args = design.argv_to_args(argv)
+        print(argv)
+        design.run(args)
+        with open(self.output.name) as f:
+            for line in f:
+                print(line)
+        #self.check_results(self.output.name, expected)
+
+    def tearDown(self):
+        for file in self.files:
+            if os.path.isfile(file):
+                os.unlink(file)
+
+class TestDesignAutos(unittest.TestCase):
+    """Test design.py
+    """
+    def setUp(self):
+        self.files = []
+
+    def test_auto_from_file(self):
+        pass
+
+    def test_auto_from_args(self):
+        pass
+
+    def tearDown(self):
+        for file in self.files:
+            if os.path.isfile(file):
+                os.unlink(file)
+
+def baseArgv(search_type='sliding-window', input_type='fasta', 
+             objective='minimize-guides', model=False, specific=None, 
+             input_file=None, output_file=None):
+
+    argv = ['design.py', search_type, input_type]
+
+    if input_type == 'fasta':
+        argv.extend([input_file, '-o', output_file, '-gl', '2'])
+    elif input_type == 'auto-from-args':
+        argv.extend(['64320', 'None', 'NC_035889', output_file])
+    elif input_type == 'auto-from-file':
+        argv.extend([input_file, '.'])
+
+    if input_type in ['auto-from-args', 'auto-from-file']:
+        argv.extend(['--sample-seqs', '1', '--mafft-path', 'fake_path'])
+
+    if search_type == 'sliding-window':
+        argv.extend(['-w', '3', '--quiet-analysis'])
+    if search_type == 'complete-targets':
+        argv.extend(['--best-n-targets', '2', '-pp', '.75', '-pl', '1', 
+                     '--max-primers-at-site', '1'])
+
+    if objective == 'minimize-guides':
+        argv.extend(['-gm', '0', '-gp', '.75'])
+
+    if specific == 'fastas':
+        argv.extend(['--specific-against-fastas', 'examples/powassan.tsv'])
+    elif specific == 'taxa':
+        argv.extend(['--specific-against-taxa', '11083'])
+
+    if model:
+        argv.extend(['--predict-activity-model-path', 'models/classify/model-51373185', 
+                     'models/regress/model-f8b6fd5d'])
+    elif objective =='maximize-activity':
+        argv.extend(['--use-simple-binary-activity-prediction', '-gm', '1'])
+
+    argv.extend(['--obj', objective, '--seed', '294', '--debug'])
+
+    return argv

--- a/bin/tests/test_design.py
+++ b/bin/tests/test_design.py
@@ -31,10 +31,10 @@ class TestDesignFasta(unittest.TestCase):
         # self.seqs["genome_2"] = "AAATA"
         # self.seqs["genome_3"] = "GGATA"
         # self.seqs["genome_4"] = "GGGAA"
-        self.seqs["genome_1"] = "AACTA-"
-        self.seqs["genome_2"] = "AAACT-"
-        self.seqs["genome_3"] = "GGCTA-"
-        self.seqs["genome_4"] = "GGCTT-"
+        self.seqs["genome_1"] = "AACTA"
+        self.seqs["genome_2"] = "AAACT"
+        self.seqs["genome_3"] = "GGCTA"
+        self.seqs["genome_4"] = "GGCTT"
 
         seq_io.write_fasta(self.seqs, self.fasta.name)
 
@@ -82,9 +82,9 @@ class TestDesignFasta(unittest.TestCase):
         args = design.argv_to_args(argv)
         print(argv)
         design.run(args)
-        with open(self.output.name) as f:
-            for line in f:
-                print(line)
+        # with open(self.output.name) as f:
+        #     for line in f:
+        #         print(line)
         #self.check_results(self.output.name, expected)
 
     def tearDown(self):
@@ -145,6 +145,6 @@ def baseArgv(search_type='sliding-window', input_type='fasta',
     elif objective =='maximize-activity':
         argv.extend(['--use-simple-binary-activity-prediction', '-gm', '1'])
 
-    argv.extend(['--obj', objective, '--seed', '294', '--debug'])
+    argv.extend(['--obj', objective, '--seed', '294'])
 
     return argv

--- a/bin/tests/test_design.py
+++ b/bin/tests/test_design.py
@@ -1,4 +1,4 @@
-"""Tests for design_naively.py
+"""Tests for design.py
 """
 
 import random

--- a/bin/tests/test_design.py
+++ b/bin/tests/test_design.py
@@ -174,7 +174,7 @@ def baseArgv(search_type='sliding-window', input_type='fasta',
         argv.extend(['--sample-seqs', '1', '--mafft-path', 'fake_path'])
 
     if search_type == 'sliding-window':
-        argv.extend(['-w', '3', '--quiet-analysis'])
+        argv.extend(['-w', '3'])
     if search_type == 'complete-targets':
         argv.extend(['--best-n-targets', '2', '-pp', '.75', '-pl', '1', 
                      '--max-primers-at-site', '2'])

--- a/bin/tests/test_design.py
+++ b/bin/tests/test_design.py
@@ -11,71 +11,129 @@ import logging
 from collections import OrderedDict
 from argparse import Namespace
 from adapt import alignment
+from adapt.prepare import align, ncbi_neighbors, prepare_alignment
 from adapt.utils import seq_io
 from bin import design
 
 __author__ = 'Priya Pillai <ppillai@broadinstitute.org>'
 
+SEQS = OrderedDict()
+# Default args: window size 3, guide size 2, allow GU pairing
+# GU pairing allows AA to match GG in 1st window
+SEQS["genome_1"] = "AACTA"
+SEQS["genome_2"] = "AAACT"
+SEQS["genome_3"] = "GGCTA"
+SEQS["genome_4"] = "GGCTT"
 
-class TestDesignFasta(unittest.TestCase):
+# Specificity seq stops AA from being the best guide in the 1st window
+SP_SEQS = OrderedDict()
+SP_SEQS["genome_5"] = "AA---"
+
+
+class TestDesign(object):
+    class TestDesignCase(unittest.TestCase):
+        def setUp(self):
+            # Disable logging
+            logging.disable(logging.INFO)
+            
+            # Create a temporary output file 
+            self.output_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+            self.output_file.close()
+
+        def check_results(self, file, expected, header='target-sequences'):
+            col_loc = None
+            with open(file) as f:
+                for i, line in enumerate(f):
+                    if i == 0:
+                        headers = line.split('\t')
+                        # Will raise an error if header is not in output
+                        col_loc = headers.index(header)
+                        continue
+                    self.assertLess(i, len(expected) + 1)
+                    guide_line = line.split('\t')[-2]
+                    guides = guide_line.split(' ')
+                    for guide in guides: 
+                        self.assertIn(guide, expected[i-1])
+                    self.assertEqual(len(guides), len(expected[i-1]))
+                self.assertEqual(i, len(expected))
+
+        @staticmethod
+        def baseArgv(search_type='sliding-window', input_type='fasta', 
+                     objective='minimize-guides', model=False, specific=None, 
+                     input_file=None, output_loc=None, specificity_file=None):
+
+            argv = ['design.py', search_type, input_type]
+
+            if input_type == 'fasta':
+                argv.extend([input_file, '-o', output_loc])
+            elif input_type == 'auto-from-args':
+                argv.extend(['64320', 'None', 'NC_035889', output_loc])
+            elif input_type == 'auto-from-file':
+                argv.extend([input_file, output_loc])
+
+            if input_type in ['auto-from-args', 'auto-from-file']:
+                argv.extend(['--sample-seqs', '1', '--mafft-path', 'fake_path'])
+
+            if search_type == 'sliding-window':
+                argv.extend(['-w', '3'])
+            if search_type == 'complete-targets':
+                argv.extend(['--best-n-targets', '2', '-pp', '.75', '-pl', '1', 
+                             '--max-primers-at-site', '2'])
+
+            if objective == 'minimize-guides':
+                argv.extend(['-gm', '0', '-gp', '.75'])
+            elif objective =='maximize-activity':
+                argv.extend(['--maximization-algorithm', 'greedy'])
+
+            if specific == 'fasta':
+                argv.extend(['--specific-against-fastas', specificity_file, '--id-m', '0'])
+            elif specific == 'taxa':
+                argv.extend(['--specific-against-taxa', specificity_file, '--id-m', '0'])
+
+            if model:
+                argv.extend(['--predict-activity-model-path', 'models/classify/model-51373185', 
+                             'models/regress/model-f8b6fd5d'])
+            elif objective =='maximize-activity':
+                argv.extend(['--use-simple-binary-activity-prediction', '-gm', '0'])
+
+            argv.extend(['--obj', objective, '--seed', '0', '-gl', '2'])
+
+            return argv
+
+        def tearDown(self):
+            for file in self.files:
+                if os.path.isfile(file):
+                    os.unlink(file)
+            # Re-enable logging
+            logging.disable(logging.NOTSET)
+
+
+class TestDesignFasta(TestDesign.TestDesignCase):
     """Test design.py given an input FASTA
     """
 
     def setUp(self):
-        # Disable logging
-        logging.disable(logging.INFO)
+        super().setUp()
 
         # Create a temporary fasta file
         self.fasta = tempfile.NamedTemporaryFile(mode='w', delete=False)
         # Closes the file so that it can be reopened on Windows
         self.fasta.close()
 
-        seqs = OrderedDict()
-        # Default args: window size 3, guide size 2, allow GU pairing
-        # GU pairing makes AA matches GG in first window
-        seqs["genome_1"] = "AACTA"
-        seqs["genome_2"] = "AAACT"
-        seqs["genome_3"] = "GGCTA"
-        seqs["genome_4"] = "GGCTT"
-
-        seq_io.write_fasta(seqs, self.fasta.name)
+        seq_io.write_fasta(SEQS, self.fasta.name)
 
         # Create a temporary fasta file for specificity
         self.sp_fasta = tempfile.NamedTemporaryFile(mode='w', delete=False)
         # Closes the file so that it can be reopened on Windows
         self.sp_fasta.close()
 
-        sp_seqs = OrderedDict()
-        sp_seqs["genome_5"] = "AA---"
-
-        seq_io.write_fasta(sp_seqs, self.sp_fasta.name)
-
-        # Create a temporary output file 
-        self.output_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
-        self.output_file.close()
+        seq_io.write_fasta(SP_SEQS, self.sp_fasta.name)
 
         self.files = [self.fasta.name, self.sp_fasta.name, self.output_file.name]
 
-    def check_results(self, file, expected, header='target-sequences'):
-        col_loc = None
-        with open(file) as f:
-            for i, line in enumerate(f):
-                if i == 0:
-                    headers = line.split('\t')
-                    # Will raise an error if header is not in output
-                    col_loc = headers.index(header)
-                    continue
-                self.assertLess(i, len(expected) + 1)
-                guide_line = line.split('\t')[-2]
-                guides = guide_line.split(' ')
-                for guide in guides: 
-                    self.assertIn(guide, expected[i-1])
-                self.assertEqual(len(guides), len(expected[i-1]))
-            self.assertEqual(i, len(expected))
-
     def test_min_guides(self):
         # Base args set the percentage of sequences to match at 75%
-        argv = baseArgv(input_file=self.fasta.name, output_loc=self.output_file.name)
+        argv = super().baseArgv(input_file=self.fasta.name, output_loc=self.output_file.name)
         args = design.argv_to_args(argv)
         design.run(args)
         expected = [["AA"], ["CT"], ["CT"]]
@@ -84,7 +142,7 @@ class TestDesignFasta(unittest.TestCase):
     def test_max_activity(self):
         # Doesn't use model, just greedy binary prediction with 0 mismatches
         # (so same outputs as min-guides)
-        argv = baseArgv(objective='maximize-activity', input_file=self.fasta.name, 
+        argv = super().baseArgv(objective='maximize-activity', input_file=self.fasta.name, 
                         output_loc=self.output_file.name)
         args = design.argv_to_args(argv)
         design.run(args)
@@ -94,7 +152,7 @@ class TestDesignFasta(unittest.TestCase):
     def test_complete_targets(self):
         # Since sequences are short and need 1 base for primer on each side, 
         # only finds 1 target in middle
-        argv = baseArgv(search_type='complete-targets', input_file=self.fasta.name, 
+        argv = super().baseArgv(search_type='complete-targets', input_file=self.fasta.name, 
                         output_loc=self.output_file.name)
         args = design.argv_to_args(argv)
         design.run(args)
@@ -103,31 +161,25 @@ class TestDesignFasta(unittest.TestCase):
                            header='guide-target-sequences')
 
     def test_specificity_fastas(self):
-        # AA isn't allowed in first window by specifity fasta, 
-        # so first window changes
-        argv = baseArgv(input_file=self.fasta.name, output_loc=self.output_file.name,
+        # AA isn't allowed in 1st window by specificity fasta, 
+        # so 1st window changes
+        argv = super().baseArgv(input_file=self.fasta.name, output_loc=self.output_file.name,
                         specific='fasta', specificity_file=self.sp_fasta.name)
         args = design.argv_to_args(argv)
         design.run(args)
         expected = [["AC", "GG"], ["CT"], ["CT"]]
         self.check_results(self.output_file.name, expected)
 
-    def tearDown(self):
-        for file in self.files:
-            if os.path.isfile(file):
-                os.unlink(file)
 
-        # Re-enable logging
-        logging.disable(logging.NOTSET)
-
-
-class TestDesignAutos(unittest.TestCase):
+class TestDesignAutos(TestDesign.TestDesignCase):
     """Test design.py given arguments to automatically download FASTAs
 
     Does not run the entire design.py; prematurely stops by giving a fake path
     to MAFFT. Expected to return a FileNotFoundError
     """
     def setUp(self):
+        super().setUp()
+        
         # Disable logging
         logging.disable(logging.INFO)
 
@@ -138,23 +190,13 @@ class TestDesignAutos(unittest.TestCase):
         # Closes the file so that it can be reopened on Windows
         self.input_file.close()
 
-        # Create a temporary input file
-        self.sp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
-        self.sp_file.write("11083\tNone\n")
-        # Closes the file so that it can be reopened on Windows
-        self.sp_file.close()
-
-        # Create a temporary output file 
-        self.output_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
-        self.output_file.close()
-
         # Create a temporary output directory 
         self.output_dir = tempfile.TemporaryDirectory()
 
-        self.files = [self.input_file.name, self.sp_file.name, self.output_file.name]
+        self.files = [self.input_file.name, self.output_file.name]
 
     def test_auto_from_file(self):
-        argv = baseArgv(input_type='auto-from-file', 
+        argv = super().baseArgv(input_type='auto-from-file', 
                         input_file=self.input_file.name, 
                         output_loc=self.output_dir.name)
         args = design.argv_to_args(argv)
@@ -164,17 +206,17 @@ class TestDesignAutos(unittest.TestCase):
             pass
 
     def test_auto_from_args(self):
-        argv = baseArgv(input_type='auto-from-args', 
-                        output_loc=self.output_file.name)
+        argv = super().baseArgv(input_type='auto-from-args', 
+                        output_loc='')
         args = design.argv_to_args(argv)
         try:
             design.run(args)
         except FileNotFoundError:
             pass
 
-    def test_specific_taxa(self):
-        argv = baseArgv(input_type='auto-from-args', output_loc=self.output_file.name,
-                        specific='taxa', specificity_file=self.sp_file.name)
+    def test_specificity_taxa(self):
+        argv = super().baseArgv(input_type='auto-from-args', output_loc='',
+                        specific='taxa', specificity_file='')
         args = design.argv_to_args(argv)
         try:
             design.run(args)
@@ -182,53 +224,71 @@ class TestDesignAutos(unittest.TestCase):
             pass
 
     def tearDown(self):
-        for file in self.files:
-            if os.path.isfile(file):
-                os.unlink(file)
+        super().tearDown()
         self.output_dir.cleanup()
-        
-        # Re-enable logging
-        logging.disable(logging.NOTSET)
 
 
-def baseArgv(search_type='sliding-window', input_type='fasta', 
-             objective='minimize-guides', model=False, specific=None, 
-             input_file=None, output_loc=None, specificity_file=None):
+class TestDesignFull(TestDesign.TestDesignCase):
+    """Test design.py fully through
+    """
+    def setUp(self):
+        super().setUp()
 
-    argv = ['design.py', search_type, input_type]
+        self.files = []
+        # Create a temporary input file
+        self.input_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        self.input_file.write("Zika virus\t64320\tNone\tNC_035889\n")
+        # Closes the file so that it can be reopened on Windows
+        self.input_file.close()
 
-    if input_type == 'fasta':
-        argv.extend([input_file, '-o', output_loc, '-gl', '2'])
-    elif input_type == 'auto-from-args':
-        argv.extend(['64320', 'None', 'NC_035889', output_loc])
-    elif input_type == 'auto-from-file':
-        argv.extend([input_file, output_loc])
+        # Create a temporary input file
+        self.sp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        self.sp_file.write("123\tNone\n")
+        # Closes the file so that it can be reopened on Windows
+        self.sp_file.close()
 
-    if input_type in ['auto-from-args', 'auto-from-file']:
-        argv.extend(['--sample-seqs', '1', '--mafft-path', 'fake_path'])
+        # Create a temporary output directory 
+        self.output_dir = tempfile.TemporaryDirectory()
 
-    if search_type == 'sliding-window':
-        argv.extend(['-w', '3'])
-    if search_type == 'complete-targets':
-        argv.extend(['--best-n-targets', '2', '-pp', '.75', '-pl', '1', 
-                     '--max-primers-at-site', '2'])
+        self.real_output_file = self.output_file.name + '.0'
+        self.files = [self.input_file.name, self.sp_file.name, self.output_file.name, \
+                      self.real_output_file]
 
-    if objective == 'minimize-guides':
-        argv.extend(['-gm', '0', '-gp', '.75'])
-    elif objective =='maximize-activity':
-        argv.extend(['--maximization-algorithm', 'greedy'])
+        self.set_mafft_exec = align.set_mafft_exec
+        align.set_mafft_exec = lambda mafft_path: None
 
-    if specific == 'fasta':
-        argv.extend(['--specific-against-fastas', specificity_file, '--id-m', '0'])
-    elif specific == 'taxa':
-        argv.extend(['--specific-against-taxa', specificity_file, '--id-m', '0'])
+        self.curate_against_ref = align.curate_against_ref
 
-    if model:
-        argv.extend(['--predict-activity-model-path', 'models/classify/model-51373185', 
-                     'models/regress/model-f8b6fd5d'])
-    elif objective =='maximize-activity':
-        argv.extend(['--use-simple-binary-activity-prediction', '-gm', '0'])
+        def small_curate(seqs, ref_accs, asm=None, remove_ref_accs=[]):
+            return {seq: seqs[seq] for seq in seqs if seq.split('.')[0] != 'NC_035889'}
 
-    argv.extend(['--obj', objective, '--seed', '294'])
+        align.curate_against_ref = small_curate
 
-    return argv
+        self.align = align.align
+        align.align = lambda seqs, am=None: SEQS
+
+        self.fetch_sequences_for_taxonomy = prepare_alignment.fetch_sequences_for_taxonomy
+
+        def small_fetch(taxid, segment):
+            if taxid == 123:
+                return SP_SEQS
+            else:
+                return self.fetch_sequences_for_taxonomy(taxid, segment)
+
+        prepare_alignment.fetch_sequences_for_taxonomy = small_fetch
+
+    def test_specificity_taxa(self):
+        argv = super().baseArgv(input_type='auto-from-args', output_loc=self.output_file.name,
+                        specific='taxa', specificity_file=self.sp_file.name)
+        args = design.argv_to_args(argv)
+        design.run(args)
+        expected = [["AC", "GG"], ["CT"], ["CT"]]
+        self.check_results(self.real_output_file, expected)
+
+    def tearDown(self):
+        align.set_mafft_exec = self.set_mafft_exec
+        align.curate_against_ref = self.curate_against_ref
+        align.align = self.align
+        prepare_alignment.fetch_sequences_for_taxonomy = self.fetch_sequences_for_taxonomy
+        super().tearDown()
+        self.output_dir.cleanup()

--- a/bin/tests/test_design.py
+++ b/bin/tests/test_design.py
@@ -17,9 +17,9 @@ from bin import design
 
 __author__ = 'Priya Pillai <ppillai@broadinstitute.org>'
 
-SEQS = OrderedDict()
 # Default args: window size 3, guide size 2, allow GU pairing
 # GU pairing allows AA to match GG in 1st window
+SEQS = OrderedDict()
 SEQS["genome_1"] = "AACTA"
 SEQS["genome_2"] = "AAACT"
 SEQS["genome_3"] = "GGCTA"
@@ -31,16 +31,41 @@ SP_SEQS["genome_5"] = "AA---"
 
 
 class TestDesign(object):
+    """General class for testing design.py
+
+    Defines helper functions for test cases and basic setUp and 
+    tearDown functions.
+    """
     class TestDesignCase(unittest.TestCase):
         def setUp(self):
             # Disable logging
             logging.disable(logging.INFO)
+
+            # Create a temporary input file
+            self.input_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+            # Closes the file so that it can be reopened on Windows
+            self.input_file.close()
             
             # Create a temporary output file 
             self.output_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
             self.output_file.close()
 
+            self.files = [self.input_file.name, self.output_file.name]
+
         def check_results(self, file, expected, header='target-sequences'):
+            """Check the results of the test output
+            
+            Given a CSV file of test output and expected output, fails the test
+            if the test output guide target sequences do not equal the expected
+            guide target sequences
+
+            Args:
+                file: string, path name of the file
+                expected: list of lists of strings, all the expected guide 
+                    target sequences in each line of the output
+                header: the header of the CSV that contains the guide target
+                    sequences
+            """
             col_loc = None
             with open(file) as f:
                 for i, line in enumerate(f):
@@ -50,18 +75,43 @@ class TestDesign(object):
                         col_loc = headers.index(header)
                         continue
                     self.assertLess(i, len(expected) + 1)
-                    guide_line = line.split('\t')[-2]
+                    guide_line = line.split('\t')[col_loc]
                     guides = guide_line.split(' ')
                     for guide in guides: 
                         self.assertIn(guide, expected[i-1])
                     self.assertEqual(len(guides), len(expected[i-1]))
                 self.assertEqual(i, len(expected))
 
-        @staticmethod
-        def baseArgv(search_type='sliding-window', input_type='fasta', 
+        def baseArgv(self, search_type='sliding-window', input_type='fasta', 
                      objective='minimize-guides', model=False, specific=None, 
-                     input_file=None, output_loc=None, specificity_file=None):
+                     specificity_file=None, input_file=None, 
+                     output_loc=None):
+            """Get arguments for tests
+            
+            Produces the correct arguments for a test case given details of 
+            what the test case is testing. See design.py help for details
+            on input
 
+            Args:
+                search_type: 'sliding-window' or 'complete-targets'
+                input_type: 'fasta', 'auto-from-args', or 'auto-from-file'
+                objective: 'minimize-guides' or 'maximize-activity'
+                model: boolean, true to use Cas13a built in model, false 
+                    to use simple binary prediction
+                specific: None, 'fasta', or 'taxa'; what sort of input
+                    to be specific against
+                input_file: path to input file, set to self.input_file.name
+                    if None
+                output_loc: path to the output file/directory; set to 
+                    self.output_file.name if None
+
+            Returns:
+                List of strings that are the arguments of the test
+            """
+            if input_file is None:
+                input_file = self.input_file.name
+            if output_loc is None:
+                output_loc = self.output_file.name
             argv = ['design.py', search_type, input_type]
 
             if input_type == 'fasta':
@@ -85,6 +135,8 @@ class TestDesign(object):
             elif objective =='maximize-activity':
                 argv.extend(['--maximization-algorithm', 'greedy'])
 
+            # ID-M (mismatches to be considered identical) must be set to 0 since otherwise
+            # having 1 base in common with a 2 base guide counts as a match
             if specific == 'fasta':
                 argv.extend(['--specific-against-fastas', specificity_file, '--id-m', '0'])
             elif specific == 'taxa':
@@ -115,13 +167,37 @@ class TestDesignFasta(TestDesign.TestDesignCase):
     def setUp(self):
         super().setUp()
 
-        # Create a temporary fasta file
-        self.fasta = tempfile.NamedTemporaryFile(mode='w', delete=False)
-        # Closes the file so that it can be reopened on Windows
-        self.fasta.close()
+        # Write to temporary input fasta
+        seq_io.write_fasta(SEQS, self.input_file.name)
 
-        seq_io.write_fasta(SEQS, self.fasta.name)
+    def test_min_guides(self):
+        argv = super().baseArgv()
+        args = design.argv_to_args(argv)
+        design.run(args)
+        # Base args set the percentage of sequences to match at 75%
+        expected = [["AA"], ["CT"], ["CT"]]
+        self.check_results(self.output_file.name, expected)
 
+    def test_max_activity(self):
+        argv = super().baseArgv(objective='maximize-activity')
+        args = design.argv_to_args(argv)
+        design.run(args)
+        # Doesn't use model, just greedy binary prediction with 0 mismatches
+        # (so same outputs as min-guides)
+        expected = [["AA"], ["CT"], ["CT"]]
+        self.check_results(self.output_file.name, expected)
+
+    def test_complete_targets(self):
+        argv = super().baseArgv(search_type='complete-targets')
+        args = design.argv_to_args(argv)
+        design.run(args)
+        # Since sequences are short and need 1 base for primer on each side, 
+        # only finds 1 target in middle
+        expected = [["CT"]]
+        self.check_results(self.output_file.name, expected, 
+                           header='guide-target-sequences')
+
+    def test_specificity_fastas(self):
         # Create a temporary fasta file for specificity
         self.sp_fasta = tempfile.NamedTemporaryFile(mode='w', delete=False)
         # Closes the file so that it can be reopened on Windows
@@ -129,44 +205,14 @@ class TestDesignFasta(TestDesign.TestDesignCase):
 
         seq_io.write_fasta(SP_SEQS, self.sp_fasta.name)
 
-        self.files = [self.fasta.name, self.sp_fasta.name, self.output_file.name]
+        self.files.append(self.sp_fasta.name)
 
-    def test_min_guides(self):
-        # Base args set the percentage of sequences to match at 75%
-        argv = super().baseArgv(input_file=self.fasta.name, output_loc=self.output_file.name)
+        argv = super().baseArgv(specific='fasta', 
+            specificity_file=self.sp_fasta.name)
         args = design.argv_to_args(argv)
         design.run(args)
-        expected = [["AA"], ["CT"], ["CT"]]
-        self.check_results(self.output_file.name, expected)
-
-    def test_max_activity(self):
-        # Doesn't use model, just greedy binary prediction with 0 mismatches
-        # (so same outputs as min-guides)
-        argv = super().baseArgv(objective='maximize-activity', input_file=self.fasta.name, 
-                        output_loc=self.output_file.name)
-        args = design.argv_to_args(argv)
-        design.run(args)
-        expected = [["AA"], ["CT"], ["CT"]]
-        self.check_results(self.output_file.name, expected)
-
-    def test_complete_targets(self):
-        # Since sequences are short and need 1 base for primer on each side, 
-        # only finds 1 target in middle
-        argv = super().baseArgv(search_type='complete-targets', input_file=self.fasta.name, 
-                        output_loc=self.output_file.name)
-        args = design.argv_to_args(argv)
-        design.run(args)
-        expected = [["CT"]]
-        self.check_results(self.output_file.name, expected, 
-                           header='guide-target-sequences')
-
-    def test_specificity_fastas(self):
         # AA isn't allowed in 1st window by specificity fasta, 
         # so 1st window changes
-        argv = super().baseArgv(input_file=self.fasta.name, output_loc=self.output_file.name,
-                        specific='fasta', specificity_file=self.sp_fasta.name)
-        args = design.argv_to_args(argv)
-        design.run(args)
         expected = [["AC", "GG"], ["CT"], ["CT"]]
         self.check_results(self.output_file.name, expected)
 
@@ -175,29 +221,20 @@ class TestDesignAutos(TestDesign.TestDesignCase):
     """Test design.py given arguments to automatically download FASTAs
 
     Does not run the entire design.py; prematurely stops by giving a fake path
-    to MAFFT. Expected to return a FileNotFoundError
+    to MAFFT. All are expected to return a FileNotFoundError
     """
     def setUp(self):
         super().setUp()
-        
-        # Disable logging
-        logging.disable(logging.INFO)
 
-        self.files = []
-        # Create a temporary input file
-        self.input_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
-        self.input_file.write("Zika virus\t64320\tNone\tNC_035889\n")
-        # Closes the file so that it can be reopened on Windows
-        self.input_file.close()
+        # Write to temporary input file
+        with open(self.input_file.name, 'w') as f:
+            f.write("Zika virus\t64320\tNone\tNC_035889\n")
 
         # Create a temporary output directory 
         self.output_dir = tempfile.TemporaryDirectory()
 
-        self.files = [self.input_file.name, self.output_file.name]
-
     def test_auto_from_file(self):
         argv = super().baseArgv(input_type='auto-from-file', 
-                        input_file=self.input_file.name, 
                         output_loc=self.output_dir.name)
         args = design.argv_to_args(argv)
         try:
@@ -206,8 +243,7 @@ class TestDesignAutos(TestDesign.TestDesignCase):
             pass
 
     def test_auto_from_args(self):
-        argv = super().baseArgv(input_type='auto-from-args', 
-                        output_loc='')
+        argv = super().baseArgv(input_type='auto-from-args')
         args = design.argv_to_args(argv)
         try:
             design.run(args)
@@ -215,7 +251,7 @@ class TestDesignAutos(TestDesign.TestDesignCase):
             pass
 
     def test_specificity_taxa(self):
-        argv = super().baseArgv(input_type='auto-from-args', output_loc='',
+        argv = super().baseArgv(input_type='auto-from-args',
                         specific='taxa', specificity_file='')
         args = design.argv_to_args(argv)
         try:
@@ -234,29 +270,28 @@ class TestDesignFull(TestDesign.TestDesignCase):
     def setUp(self):
         super().setUp()
 
-        self.files = []
-        # Create a temporary input file
-        self.input_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
-        self.input_file.write("Zika virus\t64320\tNone\tNC_035889\n")
-        # Closes the file so that it can be reopened on Windows
-        self.input_file.close()
+        # Write to temporary input file
+        with open(self.input_file.name, 'w') as f:
+            f.write("Zika virus\t64320\tNone\tNC_035889\n")
 
-        # Create a temporary input file
+        # Create a temporary specificity file
         self.sp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
         self.sp_file.write("123\tNone\n")
         # Closes the file so that it can be reopened on Windows
         self.sp_file.close()
 
-        # Create a temporary output directory 
-        self.output_dir = tempfile.TemporaryDirectory()
-
+        # 'auto-from-args' gives different outputs for every cluster
+        # Our test only produces 1 cluster, so store the name of that file
         self.real_output_file = self.output_file.name + '.0'
-        self.files = [self.input_file.name, self.sp_file.name, self.output_file.name, \
-                      self.real_output_file]
+        self.files.extend([self.sp_file.name, self.real_output_file])
 
+        # We cannot access MAFFT, so override this function; store original so 
+        # it can be fixed for future tests
         self.set_mafft_exec = align.set_mafft_exec
         align.set_mafft_exec = lambda mafft_path: None
 
+        # Curating requires MAFFT, so override this function; store original so 
+        # it can be fixed for future tests
         self.curate_against_ref = align.curate_against_ref
 
         def small_curate(seqs, ref_accs, asm=None, remove_ref_accs=[]):
@@ -264,31 +299,40 @@ class TestDesignFull(TestDesign.TestDesignCase):
 
         align.curate_against_ref = small_curate
 
+        # Aligning requires MAFFT, so override this function and output simple 
+        # test sequences; store original so it can be fixed for future tests
         self.align = align.align
         align.align = lambda seqs, am=None: SEQS
 
+        # We don't want to fetch sequences for the specificity file since we're 
+        # doing a simple test case, so override this function; store original 
+        # so it can be fixed for future tests
         self.fetch_sequences_for_taxonomy = prepare_alignment.fetch_sequences_for_taxonomy
 
         def small_fetch(taxid, segment):
+            # 123 is the taxonomic ID used in our specificity file
             if taxid == 123:
                 return SP_SEQS
+            # If it's not the specificity taxonomic ID, test fetching the real sequences,
+            # although they won't be used
             else:
                 return self.fetch_sequences_for_taxonomy(taxid, segment)
 
         prepare_alignment.fetch_sequences_for_taxonomy = small_fetch
 
     def test_specificity_taxa(self):
-        argv = super().baseArgv(input_type='auto-from-args', output_loc=self.output_file.name,
-                        specific='taxa', specificity_file=self.sp_file.name)
+        argv = super().baseArgv(input_type='auto-from-args', specific='taxa', 
+            specificity_file=self.sp_file.name)
         args = design.argv_to_args(argv)
         design.run(args)
+        # Same output as test_specificity_fasta, as sequences are the same
         expected = [["AC", "GG"], ["CT"], ["CT"]]
         self.check_results(self.real_output_file, expected)
 
     def tearDown(self):
+        # Fix all overridden functions
         align.set_mafft_exec = self.set_mafft_exec
         align.curate_against_ref = self.curate_against_ref
         align.align = self.align
         prepare_alignment.fetch_sequences_for_taxonomy = self.fetch_sequences_for_taxonomy
         super().tearDown()
-        self.output_dir.cleanup()

--- a/bin/tests/test_design.py
+++ b/bin/tests/test_design.py
@@ -27,10 +27,6 @@ class TestDesignFasta(unittest.TestCase):
         self.fasta.close()
 
         self.seqs = OrderedDict()
-        # self.seqs["genome_1"] = "AACCA"
-        # self.seqs["genome_2"] = "AAATA"
-        # self.seqs["genome_3"] = "GGATA"
-        # self.seqs["genome_4"] = "GGGAA"
         self.seqs["genome_1"] = "AACTA"
         self.seqs["genome_2"] = "AAACT"
         self.seqs["genome_3"] = "GGCTA"
@@ -80,12 +76,18 @@ class TestDesignFasta(unittest.TestCase):
         argv = baseArgv(search_type='complete-targets', input_file=self.fasta.name, 
                         output_file=self.output.name)
         args = design.argv_to_args(argv)
-        print(argv)
         design.run(args)
-        # with open(self.output.name) as f:
-        #     for line in f:
-        #         print(line)
-        #self.check_results(self.output.name, expected)
+        expected = ["objective-value\ttarget-start\ttarget-end\ttarget-length"
+                    "\tleft-primer-start\tleft-primer-num-primers\tleft-primer-frac-bound"
+                    "\tleft-primer-target-sequences\tright-primer-start"
+                    "\tright-primer-num-primers\tright-primer-frac-bound"
+                    "\tright-primer-target-sequences\tnum-guides\ttotal-frac-bound-by-guides"
+                    "\tguide-set-expected-activity\tguide-set-median-activity"
+                    "\tguide-set-5th-pctile-activity\tguide-expected-activities"
+                    "\tguide-target-sequences\tguide-target-sequence-positions\n",
+                    "3.25\t1\t5\t4\t1\t2\t1.0\tA G\t4\t2\t1.0\tA T\t1\t0.75"
+                    "\tnan\tnan\tnan\tnan\tCT\t{2}\n"]
+        self.check_results(self.output.name, expected)
 
     def tearDown(self):
         for file in self.files:
@@ -97,12 +99,36 @@ class TestDesignAutos(unittest.TestCase):
     """
     def setUp(self):
         self.files = []
+        # Create a temporary fasta file
+        self.input = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        # Closes the file so that it can be reopened on Windows
+        self.input.close()
+
+        # TODO write input file 
+
+        # Create a temporary output file 
+        self.output = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        self.output.close()
+
+        self.files = [self.input.name, self.output.name]
 
     def test_auto_from_file(self):
+        # TODO
+        # argv = baseArgv(input_type='auto_from_file', 
+        #                 input_file=self.input.name, 
+        #                 output_file=self.output.name)
+        # args = design.argv_to_args(argv)
+        # design.run(args)
         pass
 
     def test_auto_from_args(self):
-        pass
+        argv = baseArgv(input_type='auto-from-args', 
+                        output_file=self.output.name)
+        args = design.argv_to_args(argv)
+        try:
+            design.run(args)
+        except FileNotFoundError:
+            pass
 
     def tearDown(self):
         for file in self.files:
@@ -129,7 +155,7 @@ def baseArgv(search_type='sliding-window', input_type='fasta',
         argv.extend(['-w', '3', '--quiet-analysis'])
     if search_type == 'complete-targets':
         argv.extend(['--best-n-targets', '2', '-pp', '.75', '-pl', '1', 
-                     '--max-primers-at-site', '1'])
+                     '--max-primers-at-site', '2'])
 
     if objective == 'minimize-guides':
         argv.extend(['-gm', '0', '-gp', '.75'])

--- a/bin/tests/test_design.py
+++ b/bin/tests/test_design.py
@@ -55,7 +55,7 @@ class TestDesign(object):
         def check_results(self, file, expected, header='target-sequences'):
             """Check the results of the test output
             
-            Given a CSV file of test output and expected output, fails the test
+            Given a TSV file of test output and expected output, fails the test
             if the test output guide target sequences do not equal the expected
             guide target sequences
 
@@ -84,8 +84,7 @@ class TestDesign(object):
 
         def baseArgv(self, search_type='sliding-window', input_type='fasta', 
                      objective='minimize-guides', model=False, specific=None, 
-                     specificity_file=None, input_file=None, 
-                     output_loc=None):
+                     specificity_file=None, output_loc=None):
             """Get arguments for tests
             
             Produces the correct arguments for a test case given details of 
@@ -100,16 +99,13 @@ class TestDesign(object):
                     to use simple binary prediction
                 specific: None, 'fasta', or 'taxa'; what sort of input
                     to be specific against
-                input_file: path to input file, set to self.input_file.name
-                    if None
                 output_loc: path to the output file/directory; set to 
                     self.output_file.name if None
 
             Returns:
                 List of strings that are the arguments of the test
             """
-            if input_file is None:
-                input_file = self.input_file.name
+            input_file = self.input_file.name
             if output_loc is None:
                 output_loc = self.output_file.name
             argv = ['design.py', search_type, input_type]

--- a/bin/tests/test_design_naively.py
+++ b/bin/tests/test_design_naively.py
@@ -143,6 +143,10 @@ class TestDesignNaively(unittest.TestCase):
                                             [('CA', -30), ('GG', -20), ('TG', 0)], 
                                             [('CA', -30), ('GG', -20), ('AA', -10)]])
 
+    def tearDown(self):
+        # Re-enable logging
+        logging.disable(logging.NOTSET)
+
 
 def baseArgs():
     args = Namespace()

--- a/bin/tests/test_design_naively.py
+++ b/bin/tests/test_design_naively.py
@@ -2,6 +2,7 @@
 """
 
 import random
+import logging
 import copy
 import unittest
 
@@ -15,6 +16,10 @@ __author__ = 'Priya Pillai <ppillai@broadinstitute.org>'
 class TestDesignNaively(unittest.TestCase):
     """Test design_naively.py
     """
+
+    def setUp(self):
+        # Disable logging
+        logging.disable(logging.INFO)
 
     def test_construct_guide_naively_at_each_pos_simple(self):
         ref_seq = 'ACAAA'
@@ -83,42 +88,60 @@ class TestDesignNaively(unittest.TestCase):
 
     def test_find_guide_in_each_window_simple(self):
         guides = [('TT', 50),
-                  ('GT', 30),
+                  ('TG', 30),
                   ('GG', 10),
-                  ('CG', 40),
+                  ('GC', 40),
                   ('CC', 60),
                   ('CA', 70),
                   ('AA', 20)]
 
         args = baseArgs()
-        max_windows = design_naively.find_guide_in_each_window(guides, len(guides) + 1, args)
-        min_windows = design_naively.find_guide_in_each_window(guides, len(guides) + 1, args, obj_type='min')
+        test_max_windows = design_naively.find_guide_in_each_window(guides, len(guides) + 1, args)
+        self.assertEqual(test_max_windows, [[('CC', 60), ('TT', 50), ('GC', 40)], 
+                                            [('CA', 70), ('CC', 60), ('GC', 40)], 
+                                            [('CA', 70), ('CC', 60), ('GC', 40)]])
+        test_min_windows = design_naively.find_guide_in_each_window(guides, len(guides) + 1, args, obj_type='min')
+        self.assertEqual(test_min_windows, [[('GG', 10), ('TG', 30), ('GC', 40)], 
+                                            [('GG', 10), ('TG', 30), ('GC', 40)], 
+                                            [('GG', 10), ('AA', 20), ('GC', 40)]])
 
     def test_find_guide_in_each_window_ties(self):
-        guides = [('TT', 30),
-                  ('GT', 30),
+        guides = [('TT', 10),
+                  ('TG', 30),
                   ('GG', 10),
-                  ('CG', 10),
+                  ('GC', 10),
                   ('CC', 10),
-                  ('CA', 10),
+                  ('CA', 30),
                   ('AA', 30)]
 
         args = baseArgs()
-        max_windows = design_naively.find_guide_in_each_window(guides, len(guides) + 1, args)
-        min_windows = design_naively.find_guide_in_each_window(guides, len(guides) + 1, args, obj_type='min')
+        test_max_windows = design_naively.find_guide_in_each_window(guides, len(guides) + 1, args)
+        self.assertEqual(test_max_windows, [[('TG', 30), ('TT', 10), ('GG', 10)], 
+                                            [('TG', 30), ('CA', 30), ('GG', 10)], 
+                                            [('CA', 30), ('AA', 30), ('GG', 10)]])
+        test_min_windows = design_naively.find_guide_in_each_window(guides, len(guides) + 1, args, obj_type='min')
+        self.assertEqual(test_min_windows, [[('TT', 10), ('GG', 10), ('GC', 10)], 
+                                            [('GG', 10), ('GC', 10), ('CC', 10)], 
+                                            [('GG', 10), ('GC', 10), ('CC', 10)]])
 
     def test_find_guide_in_each_window_negative(self):
         guides = [('TT', 30),
-                  ('GT', 0),
+                  ('TG', 0),
                   ('GG', -20),
-                  ('CG', 10),
+                  ('GC', 10),
                   ('CC', 20),
                   ('CA', -30),
                   ('AA', -10)]
 
         args = baseArgs()
-        max_windows = design_naively.find_guide_in_each_window(guides, len(guides) + 1, args)
-        min_windows = design_naively.find_guide_in_each_window(guides, len(guides) + 1, args, obj_type='min')
+        test_max_windows = design_naively.find_guide_in_each_window(guides, len(guides) + 1, args)
+        self.assertEqual(test_max_windows, [[('TT', 30), ('CC', 20), ('GC', 10)], 
+                                            [('CC', 20), ('GC', 10), ('TG', 0)], 
+                                            [('CC', 20), ('GC', 10), ('AA', -10)]])
+        test_min_windows = design_naively.find_guide_in_each_window(guides, len(guides) + 1, args, obj_type='min')
+        self.assertEqual(test_min_windows, [[('GG', -20), ('TG', 0), ('GC', 10)], 
+                                            [('CA', -30), ('GG', -20), ('TG', 0)], 
+                                            [('CA', -30), ('GG', -20), ('AA', -10)]])
 
 
 def baseArgs():


### PR DESCRIPTION
Integration tests for design.py, including testing for `fasta`, `auto-from-args`, `auto-from-file`, `sliding-window`, `complete-targets`, `minimize-guides`, `maximize-activity`, `specific-against-fasta`, and `specific-against-taxa`.
Edits besides integration tests:
* `Exception` > `FileNotFoundError` when MAFFT can't be found to make it easier to catch specifically
* Set `print_analysis` in `sliding-windows` to be based on if the logging level was verbose or not. 
* Restructuring of design.py for testing purposes