### PR TITLE
Change log message for no guides in window from warn to debug level

### DIFF
--- a/adapt/guide_search.py
+++ b/adapt/guide_search.py
@@ -481,7 +481,7 @@ class GuideSearcher:
             raise ValueError(("window size must be < the length of the "
                               "alignment"))
         if window_size < self.guide_length:
-            raise ValueError("window size must be >= guide length") 
+            raise ValueError("window size must be >= guide length")
 
         for start in range(0, self.aln.seq_length - window_size + 1,
                 window_step):
@@ -676,7 +676,7 @@ class GuideSearcherMinimizeGuides(GuideSearcher):
 
             key = (seqs_to_consider_frozen, num_needed_frozen)
             return key
-        
+
         p = super()._compute_guide_memoized(start, construct_p, make_key,
                 use_last=use_last)
         return p
@@ -1170,7 +1170,7 @@ class GuideSearcherMinimizeGuides(GuideSearcher):
                 num_with_min_count = sum(1 for x in guide_collections
                     if len(x[2]) == min_count)
 
-                min_count_str = (str(min_count) + " guide" + 
+                min_count_str = (str(min_count) + " guide" +
                                  ("s" if min_count > 1 else ""))
 
                 stat_display = [
@@ -1287,7 +1287,7 @@ class GuideSearcherMaximizeActivity(GuideSearcher):
         if activities is None:
             activities = self.guide_set_activities(window_start, window_end,
                     guide_set)
-        
+
         # Use the mean (i.e., uniform prior over target sequences)
         expected_activity = np.mean(activities)
 
@@ -1833,7 +1833,7 @@ class GuideSearcherMaximizeActivity(GuideSearcher):
             # It is possible no guides can be found (e.g., if they all
             # create negative objective values)
             if self.algorithm == 'random-greedy':
-                logger.warning(("No guides could be found, possibly because "
+                logger.debug(("No guides could be found, possibly because "
                     "the ground set in this window is empty. 'random-greedy' "
                     "restricts the ground set so that the objective function "
                     "is non-negative. This is more likely to be the case "


### PR DESCRIPTION
The guide searcher is highly likely to find windows with no guides; changing this message to a debug reduces excessive logging.