### PR TITLE
Add option to design naively using n most common sequences

### DIFF
--- a/adapt/alignment.py
+++ b/adapt/alignment.py
@@ -584,13 +584,13 @@ class Alignment(SequenceList):
 
         return consensus
 
-    def determine_most_common_sequence(self, seqs_to_consider=None,
-            skip_ambiguity=False):
+    def determine_most_common_sequences(self, seqs_to_consider=None,
+            skip_ambiguity=False, n=1):
         """Determine the most common of the sequences from the alignment.
 
         If we imagine each sequence in the alignment as existing some
         number of times in the alignment, this effectively picks the
-        mode.
+        mode when n is 1.
 
         Ties are broken arbitrarily but deterministically.
 
@@ -600,10 +600,12 @@ class Alignment(SequenceList):
             skip_ambiguity: if True, ignore any sequences that contain
                 an ambiguity code (i.e., only count sequences where all
                 bases are 'A', 'T', 'C', or 'G')
+            n: number of sequences to return. If there are <n unique sequences,
+                all sequences are return in order of count
 
         Returns:
-            str representing the mode of the sequences (or None if there
-            are no suitable strings)
+            list of str representing the n most common of the sequences (or
+            None if there are no suitable strings)
         """
         if seqs_to_consider is None:
             seqs_to_consider = range(self.num_sequences)
@@ -631,10 +633,11 @@ class Alignment(SequenceList):
             # There are no suitable strings (e.g., all contain ambiguity)
             return None
 
-        # Find the most common sequence (sort to break ties deterministically)
-        counts_sorted = sorted(list(seq_count.items()))
-        max_seq_str = max(counts_sorted, key=lambda x: x[1])[0]
-        return max_seq_str
+        # Find the most common sequence (break ties by arbitrarily by sequence)
+        counts_sorted = sorted(list(seq_count.items()),
+                               key=lambda x: (-x[1], x[0]))
+        max_seq_strs = [count_sorted[0] for count_sorted in counts_sorted[0:n]]
+        return max_seq_strs
 
     def determine_representative_guides(self, start, guide_length,
             seqs_to_consider, guide_clusterer, missing_threshold=1,

--- a/adapt/alignment.py
+++ b/adapt/alignment.py
@@ -601,11 +601,11 @@ class Alignment(SequenceList):
                 an ambiguity code (i.e., only count sequences where all
                 bases are 'A', 'T', 'C', or 'G')
             n: number of sequences to return. If there are <n unique sequences,
-                all sequences are return in order of count
+                all sequences are returned
 
         Returns:
-            list of str representing the n most common of the sequences (or
-            None if there are no suitable strings)
+            list of str representing the n most common of the sequences in
+            order of count (or None if there are no suitable strings)
         """
         if seqs_to_consider is None:
             seqs_to_consider = range(self.num_sequences)

--- a/adapt/tests/test_alignment.py
+++ b/adapt/tests/test_alignment.py
@@ -543,12 +543,18 @@ class TestAlignment(unittest.TestCase):
                          [0,1,2,3,4])
 
     def test_most_common_sequence_simple(self):
-        self.assertEqual(self.d_seqs_aln.determine_most_common_sequence(
+        self.assertEqual(self.d_seqs_aln.determine_most_common_sequences(
                             skip_ambiguity=False),
-                         'ATCGAA')
-        self.assertEqual(self.d_seqs_aln.determine_most_common_sequence(
+                         ['ATCGAA'])
+        self.assertEqual(self.d_seqs_aln.determine_most_common_sequences(
                             skip_ambiguity=True),
-                         'ATCGAA')
+                         ['ATCGAA'])
+        self.assertEqual(self.d_seqs_aln.determine_most_common_sequences(
+                            n=2),
+                         ['ATCGAA','GGGCCC'])
+        self.assertEqual(self.d_seqs_aln.determine_most_common_sequences(
+                            n=3),
+                         ['ATCGAA','GGGCCC'])
 
     def test_most_common_sequence_with_ambiguity(self):
         seqs = ['ATCNAA',
@@ -560,10 +566,18 @@ class TestAlignment(unittest.TestCase):
                 'GGGCCC']
         aln = alignment.Alignment.from_list_of_seqs(seqs)
 
-        self.assertEqual(aln.determine_most_common_sequence(skip_ambiguity=False),
-                         'ATCNAA')
-        self.assertEqual(aln.determine_most_common_sequence(skip_ambiguity=True),
-                         'GGGCCC')
+        self.assertEqual(aln.determine_most_common_sequences(skip_ambiguity=False),
+                         ['ATCNAA'])
+        self.assertEqual(aln.determine_most_common_sequences(skip_ambiguity=True),
+                         ['GGGCCC'])
+        self.assertEqual(aln.determine_most_common_sequences(skip_ambiguity=False, n=2),
+                         ['ATCNAA', 'GGGCCC'])
+        self.assertEqual(aln.determine_most_common_sequences(skip_ambiguity=True, n=2),
+                         ['GGGCCC', 'ATCGAA'])
+        self.assertEqual(aln.determine_most_common_sequences(skip_ambiguity=False, n=3),
+                         ['ATCNAA', 'GGGCCC', 'ATCGAA'])
+        self.assertEqual(aln.determine_most_common_sequences(skip_ambiguity=True, n=3),
+                         ['GGGCCC', 'ATCGAA'])
 
     def test_position_entropy_simple(self):
         seqs = ['ACCCC',

--- a/bin/design_naively.py
+++ b/bin/design_naively.py
@@ -354,7 +354,8 @@ if __name__ == "__main__":
 
     parser.add_argument('--mode-n', type=int, default=1,
             help=("Use the MODE_N most common sequences as the 'mode' "
-                "sequences; defaults to 1"))
+                "sequences; note that this is no longer the 'mode' of the "
+                "data. Defaults to 1."))
 
     # Requiring flanking sequence (PFS)
     parser.add_argument('--require-flanking5',

--- a/bin/design_naively.py
+++ b/bin/design_naively.py
@@ -70,8 +70,9 @@ def construct_guide_naively_at_each_pos(aln, args, ref_seq=None):
                     consensus_guide = aln_for_guide.determine_consensus_sequence(
                             seqs_to_consider=seqs_to_consider)
                 if args.mode:
-                    mode_guide = aln_for_guide.determine_most_common_sequence(
-                            seqs_to_consider=seqs_to_consider, skip_ambiguity=True) \
+                    mode_guide = aln_for_guide.determine_most_common_sequences(
+                            seqs_to_consider=seqs_to_consider,
+                            skip_ambiguity=True)[0]
 
             if len(ref_seqs_to_consider) > 0:
                 if args.diversity:

--- a/bin/design_naively.py
+++ b/bin/design_naively.py
@@ -97,17 +97,19 @@ def construct_guide_naively_at_each_pos(aln, args, ref_seq=None):
                 mode_guides_bound.append(aln.sequences_bound_by_guide(
                         mode_guide, i, args.guide_mismatches,
                         args.allow_gu_pairs, required_flanking_seqs=args.required_flanking_seqs))
-            all_mode_guides_bound = set()
-            for mode_guide_bound in mode_guides_bound:
-                all_mode_guides_bound |= set(mode_guide_bound)
-            mode_guide_frac = (float(len(all_mode_guides_bound)) /
-                               aln.num_sequences)
+            all_mode_guides_bound = set().union(*mode_guides_bound)
+            # total_mode_guides_frac is the fraction of sequences bound by at
+            # least one of the guides
+            total_mode_guides_frac = (float(len(all_mode_guides_bound)) /
+                                      aln.num_sequences)
+            # mode_guides_frac is a list of the fraction of sequences bound by
+            # each guides
             mode_guides_frac = [(float(len(mode_guide_bound)) /
                                  aln.num_sequences)
                                 for mode_guide_bound in mode_guides_bound]
         else:
             mode_guides = 'None'
-            mode_guide_frac = 0
+            total_mode_guides_frac = 0
             mode_guides_frac = [0]
 
         if diversity_guide is not None:
@@ -129,7 +131,7 @@ def construct_guide_naively_at_each_pos(aln, args, ref_seq=None):
         if args.consensus:
             d['consensus'] = (consensus_guide, consensus_guide_frac)
         if args.mode:
-            d['mode'] = ((mode_guides, mode_guides_frac), mode_guide_frac)
+            d['mode'] = ((mode_guides, mode_guides_frac), total_mode_guides_frac)
         if args.diversity:
             d[args.diversity] = ((diversity_guide, diversity_guide_frac), diversity_metric)
         guides[i] = d

--- a/bin/design_naively.py
+++ b/bin/design_naively.py
@@ -39,7 +39,8 @@ def construct_guide_naively_at_each_pos(aln, args, ref_seq=None):
     """
     start_positions = range(aln.seq_length - args.guide_length + 1)
     guides = [None for _ in start_positions]
-    ref_seq_aln = alignment.Alignment.from_list_of_seqs([ref_seq])
+    if ref_seq is not None:
+        ref_seq_aln = alignment.Alignment.from_list_of_seqs([ref_seq])
     for i in start_positions:
         # Extract the portion of the alignment that starts at i
         pos_start, pos_end = i, i + args.guide_length
@@ -52,8 +53,10 @@ def construct_guide_naively_at_each_pos(aln, args, ref_seq=None):
         # Only look at sequences with valid flanking regions
         seqs_to_consider = aln.seqs_with_required_flanking(i, args.guide_length,
                 args.required_flanking_seqs, seqs_to_consider=seqs_to_consider)
-        ref_seqs_to_consider = ref_seq_aln.seqs_with_required_flanking(
-                i, args.guide_length, args.required_flanking_seqs)
+        ref_seqs_to_consider = []
+        if ref_seq is not None:
+            ref_seqs_to_consider = ref_seq_aln.seqs_with_required_flanking(
+                    i, args.guide_length, args.required_flanking_seqs)
 
         consensus_guide = None
         mode_guide = None

--- a/bin/tests/test_design_naively.py
+++ b/bin/tests/test_design_naively.py
@@ -45,7 +45,26 @@ class TestDesignNaively(unittest.TestCase):
 
         args.consensus = False
         args.mode = True
-        self.assertEqual(test_seqs(seqs, args), [('GG', 0.5), ('AA', 0.375), ('AA', 0.5), ('AA', 0.75)])
+        self.assertEqual(test_seqs(seqs, args),  [((['GG'], [0.5]), 0.5),
+                                                  ((['AA'], [0.375]), 0.375),
+                                                  ((['AA'], [0.5]), 0.5),
+                                                  ((['AA'], [0.75]), 0.75)])
+        args.mode_n = 2
+        self.assertEqual(test_seqs(seqs, args),  [((['GG', 'AA'], [0.5, 0.375]), 0.875),
+                                                  ((['AA', 'GA'], [0.375, 0.25]), 0.625),
+                                                  ((['AA', 'AT'], [0.5, .25]), 0.75),
+                                                  ((['AA','TA'], [0.75, 0.25]), 1)])
+        args.mode_n = 3
+        self.assertEqual(test_seqs(seqs, args),  [((['GG', 'AA', 'AC'], [0.5, 0.375, 0.125]), 1),
+                                                  ((['AA', 'GA', 'GT'], [0.375, 0.25, 0.25]), 0.875),
+                                                  ((['AA', 'AT', 'TA'], [0.5, 0.25, 0.25]), 1),
+                                                  ((['AA','TA'], [0.75, 0.25]), 1)])
+
+        args.mode_n = 4
+        self.assertEqual(test_seqs(seqs, args),  [((['GG', 'AA', 'AC'], [0.5, 0.375, 0.125]), 1),
+                                                  ((['AA', 'GA', 'GT', 'CA'], [0.375, 0.25, 0.25, 0.125]), 1),
+                                                  ((['AA', 'AT', 'TA'], [0.5, 0.25, 0.25]), 1),
+                                                  ((['AA','TA'], [0.75, 0.25]), 1)])
 
         args.mode = False
         args.diversity = 'entropy'
@@ -78,7 +97,22 @@ class TestDesignNaively(unittest.TestCase):
 
         args.consensus = False
         args.mode = True
-        self.assertEqual(test_seqs(seqs, args), [('None', 0), ('GT', 0.25), ('AT', 0.25), ('None', 0)])
+        self.assertEqual(test_seqs(seqs, args), [(('None', [0]), 0),
+                                                 ((['GT'], [0.25]), 0.25),
+                                                 ((['AT'], [0.25]), 0.25),
+                                                 (('None', [0]), 0)])
+
+        args.mode_n = 2
+        self.assertEqual(test_seqs(seqs, args), [(('None', [0]), 0),
+                                                 ((['GT'], [0.25]), 0.25),
+                                                 ((['AT', "TA"], [0.25, 0.25]), 0.5),
+                                                 (('None', [0]), 0)])
+
+        args.mode_n = 3
+        self.assertEqual(test_seqs(seqs, args), [(('None', [0]), 0),
+                                                 ((['GT'], [0.25]), 0.25),
+                                                 ((['AT', 'TA', 'AA'], [0.25, 0.25, 0.125]), 0.625),
+                                                 (('None', [0]), 0)])
 
         args.mode = False
         args.diversity = 'entropy'
@@ -161,6 +195,7 @@ def baseArgs():
     args.allow_gu_pairs = False
     args.best_n = 3
     args.required_flanking_seqs = (None, None)
+    args.mode_n = 1
 
     return args
 


### PR DESCRIPTION
Allow design_naively to output the n most common sequences as a guide set. 
Make as a variant of `mode` output, using `--mode-n` input to specify how many sequences to output.
Also, fix bug in design_naively that raised an error if a reference sequence was not input even if none was needed.
Note: For window sizes >1 guide length, the best guide set will be determined by the efficiency of `MODE_N` guides at each site with no penalty for a larger guide set