### PR TITLE
Modify expected activity per guide to only use sequences where the guide is the best of the set

### DIFF
--- a/adapt/guide_search.py
+++ b/adapt/guide_search.py
@@ -398,6 +398,84 @@ class GuideSearcher:
 
         return np.mean(activities)
 
+    def guide_set_activities_per_guide(self, window_start,
+            window_end, guide_set):
+        """Compute expected activity across target sequences for
+        a guide set in a window.
+
+        This assumes the distribution across target sequences is uniform,
+        so it is equivalent to the mean.
+
+        Args:
+            window_start/window_end: start (inclusive) and end (exclusive)
+                positions of the window
+            guide_set: set of strings representing guide sequences that
+                have been selected to be in a guide set
+
+        Returns:
+            ({guide sequence: list of activities per sequence}, max_activity)
+                where max_activity is a list of activities across the target
+                sequences (self.aln) yielded by the best of guide_set on each
+                seq
+        """
+        if self.predictor is None:
+            raise NoPredictorError(("Cannot compute activities when "
+                "predictor is not set"))
+
+        activities = np.zeros(self.aln.num_sequences)
+        per_gd_activities = {}
+        for gd_seq in guide_set:
+            if gd_seq not in self._selected_guide_positions:
+                raise Exception(("Guide must be selected and its position "
+                    "saved"))
+
+            # The guide could hit multiple places
+            for start in self._selected_guide_positions[gd_seq]:
+                if start < window_start or start > window_end - len(gd_seq):
+                    # Guide is outside window
+                    continue
+                try:
+                    gd_activities = self.aln.compute_activity(start, gd_seq,
+                            self.predictor)
+                except alignment.CannotConstructGuideError:
+                    # Most likely this site is too close to an endpoint and
+                    # does not have enough context_nt; skip it
+                    continue
+
+                per_gd_activities[gd_seq] = gd_activities
+                # Update activities with gd_activities
+                activities = np.maximum(activities, gd_activities)
+
+        return per_gd_activities, activities
+
+    def guide_set_activities_expected_value_per_guide(self, window_start,
+            window_end, guide_set):
+        """Compute expected activity across target sequences for
+        a guide set in a window.
+
+        This assumes the distribution across target sequences is uniform,
+        so it is equivalent to the mean.
+
+        Args:
+            window_start/window_end: start (inclusive) and end (exclusive)
+                positions of the window
+            guide_set: set of strings representing guide sequences that
+                have been selected to be in a guide set
+
+        Returns:
+            expected (here, mean) activity
+        """
+        per_gd_activities, activities = self.guide_set_activities_per_guide(
+            window_start, window_end, guide_set)
+
+        per_gd_expected_activities = {}
+        for gd_seq in guide_set:
+            best_guide = per_gd_activities[gd_seq] == activities
+            per_gd_expected_activities[gd_seq] = np.mean(
+                per_gd_activities[gd_seq][best_guide])
+
+        return per_gd_expected_activities
+
     def guide_activities_expected_value(self, window_start, window_end, gd_seq):
         """Compute expected activity across target sequences for a single
         guide in a window.
@@ -1902,9 +1980,12 @@ class GuideSearcherMaximizeActivity(GuideSearcher):
                 positions = [self._selected_guide_positions[gd_seq]
                              for gd_seq in guide_seqs_sorted]
                 positions_str = ' '.join(str(p) for p in positions)
+                expected_activities_per_guide_dict = \
+                        self.guide_set_activities_expected_value_per_guide(
+                            start, end, guide_seqs)
                 expected_activities_per_guide = \
-                        [self.guide_activities_expected_value(start, end,
-                            gd_seq) for gd_seq in guide_seqs_sorted]
+                        [expected_activities_per_guide_dict[gd_seq]
+                         for gd_seq in guide_seqs_sorted]
                 expected_activities_per_guide_str = ' '.join(
                         str(a) for a in expected_activities_per_guide)
                 line = [start, end, count, obj, frac_bound,

--- a/adapt/target_search.py
+++ b/adapt/target_search.py
@@ -626,10 +626,12 @@ class TargetSearcher:
                 window_start = p1.start + p1.primer_length
                 window_end = p2.start
                 if self.gs.predictor is not None:
+                    expected_activities_per_guide_dict = \
+                            self.guide_set_activities_expected_value_per_guide(
+                                window_start, window_end, guides_seqs_sorted)
                     expected_activities_per_guide = \
-                            [self.gs.guide_activities_expected_value(
-                                window_start, window_end, gd_seq)
-                                for gd_seq in guides_seqs_sorted]
+                            [expected_activities_per_guide_dict[gd_seq]
+                             for gd_seq in guides_seqs_sorted]
                 else:
                     # There is no predictor to predict activities
                     # This should only be the case if self.obj_type is 'min',

--- a/adapt/tests/test_guide_search.py
+++ b/adapt/tests/test_guide_search.py
@@ -957,6 +957,41 @@ class TestGuideSearcherMaximizeActivity(unittest.TestCase):
                 guides, [5, 50])
         self.assertEqual(activities_percentile, [0, 2])
 
+    def test_guide_set_activities_per_guide(self):
+        gs = self.make_gs(['ATCGAATTCG',
+                           'GGGAGGGGGG',
+                           'CCCCCCCCCC',
+                           'AACGAATTCG'],
+                           hard_guide_constraint=2,
+                           algorithm='greedy')
+        # Guides should be 'AATT' and 'AGGG'
+        guides = gs._find_guides_in_window(2, 8)
+
+        per_gd_activities, activities = gs.guide_set_activities_per_guide(
+            2, 8, guides)
+        np.testing.assert_equal(activities, np.array([2, 2, 0, 2],))
+        self.assertIn('AATT', per_gd_activities)
+        self.assertIn('AGGG', per_gd_activities)
+        np.testing.assert_equal(per_gd_activities['AATT'], np.array([2, 0, 0, 2]))
+        np.testing.assert_equal(per_gd_activities['AGGG'], np.array([0, 2, 0, 0]))
+
+    def test_guide_set_activities_expected_value_per_guide(self):
+        gs = self.make_gs(['ATCGAATTCG',
+                           'GGGAGGGGGG',
+                           'CCCCCCCCCC',
+                           'AACGAATTCG'],
+                           hard_guide_constraint=2,
+                           algorithm='greedy')
+        # Guides should be 'AATT' and 'AGGG'
+        guides = gs._find_guides_in_window(2, 8)
+
+        per_gd_expected = gs.guide_set_activities_expected_value_per_guide(
+            2, 8, guides)
+        self.assertIn('AATT', per_gd_expected)
+        self.assertIn('AGGG', per_gd_expected)
+        self.assertEqual(per_gd_expected['AATT'], 4/3)
+        self.assertEqual(per_gd_expected['AGGG'], 1)
+
     def test_guide_activities_expected_value(self):
         gs = self.make_gs(['ATCGAATTCG',
                            'GGGAGGGGGG',


### PR DESCRIPTION
Only use sequences where the guide is the best of the guide set when calculating expected activity. If sequence ties against multiple guides, it will be counted for all of them.

**Details**

In `guide_search.py`
- Add `guide_set_activities_per_guide` & `guide_set_activities_expected_value_per_guide`
- Use `guide_set_activities_expected_value_per_guide` in `expected_activities_per_guide` output
  **This makes `guide_activities_expected_value` obsolete, but still in code**

In `target_search.py`
- Use `guide_set_activities_expected_value_per_guide` in `expected_activities_per_guide` output