### PR TITLE
Consider consensus of all sequences when selecting guides

### DIFF
--- a/adapt/alignment.py
+++ b/adapt/alignment.py
@@ -724,7 +724,7 @@ class Alignment(SequenceList):
                 "a gap and/or do not contain required flanking sequences"))
 
         representatives = set()
-        def consider_guide(gd):
+        def consider_and_add_guide(gd):
             if 'N' in gd:
                 # Skip this guide; all sequences at a position in the cluster
                 # under consideration are 'N'
@@ -742,7 +742,7 @@ class Alignment(SequenceList):
             # sequences
             gd = aln_for_guide.determine_consensus_sequence(
                     all_seqs_to_consider)
-            consider_guide(gd)
+            consider_and_add_guide(gd)
 
         # Cluster the sequences
         seq_rows = aln_for_guide.make_list_of_seqs(all_seqs_to_consider,
@@ -753,7 +753,7 @@ class Alignment(SequenceList):
         for cluster_idxs in clusters:
             gd = aln_for_guide.determine_consensus_sequence(
                 cluster_idxs)
-            consider_guide(gd)
+            consider_and_add_guide(gd)
 
         return representatives
 

--- a/adapt/alignment.py
+++ b/adapt/alignment.py
@@ -423,6 +423,12 @@ class Alignment(SequenceList):
             # Cluster the sequences
             clusters = guide_clusterer.cluster(seq_rows)
 
+            # Include, as a "cluster", all sequences to consider -- in case
+            # the consensus of all the sequences happens to do a better job
+            # detecting the sequences than the consensus of any individual
+            # cluster
+            clusters = [all_seqs_to_consider] + list(clusters)
+
             # Sort the clusters by score, from highest to lowest
             # Here, the score is determined by the sequences in the cluster
             clusters_ordered = sorted(clusters, key=seq_idxs_score, reverse=True)

--- a/adapt/tests/test_alignment.py
+++ b/adapt/tests/test_alignment.py
@@ -454,6 +454,10 @@ class TestAlignment(unittest.TestCase):
             k=3)
         seqs_to_consider = {0: set(range(len(seqs)))}
 
+        # Note that, along with being a cluster consensus, 'CATTTT' is also the
+        # overall consensus (according to how the consensus function is
+        # defined, which takes the most common allele)
+
         representatives = aln.determine_representative_guides(0,
                 guide_length, seqs_to_consider, guide_clusterer)
         self.assertSetEqual(representatives,

--- a/adapt/tests/test_alignment.py
+++ b/adapt/tests/test_alignment.py
@@ -446,7 +446,7 @@ class TestAlignment(unittest.TestCase):
                 'TCAAAT',
                 'TCAAAT',
                 'TCAAAA',
-                'T-GGAA']
+                'T-GGTA']
         aln = alignment.Alignment.from_list_of_seqs(seqs)
         guide_length = 6
         guide_clusterer = alignment.SequenceClusterer(
@@ -462,6 +462,33 @@ class TestAlignment(unittest.TestCase):
                 guide_length, seqs_to_consider, guide_clusterer)
         self.assertSetEqual(representatives,
                 {'TCAAAT', 'CCAAAA', 'GGGGGG', 'CATTTT'})
+
+    def test_determine_representative_guides_with_distinct_consensus(self):
+        # Here, unlike above, the overall consensus is not a cluster consensus
+        seqs = ['TCAAAT',
+                'CCAAAA',
+                'CATTTT',
+                'CATTTT',
+                'CATTTA',
+                'GGGGGG',
+                'CATTTA',
+                'CATTTA',
+                'CATTTA',
+                'TCAAAT',
+                'TCAAAT',
+                'TCAAAT',
+                'T-GGAT']
+        aln = alignment.Alignment.from_list_of_seqs(seqs)
+        guide_length = 6
+        guide_clusterer = alignment.SequenceClusterer(
+            lsh.HammingDistanceFamily(guide_length),
+            k=3)
+        seqs_to_consider = {0: set(range(len(seqs)))}
+
+        representatives = aln.determine_representative_guides(0,
+                guide_length, seqs_to_consider, guide_clusterer)
+        self.assertSetEqual(representatives,
+                {'TCAAAT', 'CCAAAA', 'GGGGGG', 'CATTTA', 'CATTTT'})
 
     def test_compute_activity(self):
         # Predict guides matching target to have activity 1, and

--- a/bin/tests/test_design.py
+++ b/bin/tests/test_design.py
@@ -93,7 +93,10 @@ class TestDesign(object):
                             is_correct = False
                         if is_correct:
                             an_option_is_ok = True
-                    self.assertTrue(an_option_is_ok)
+                    self.assertTrue(an_option_is_ok,
+                            msg=(f"The design with guides {guides} does "
+                                f"not match any expected solution "
+                                f"({ei})"))
                 self.assertEqual(i, len(expected))
 
         def baseArgv(self, search_type='sliding-window', input_type='fasta',

--- a/bin/tests/test_design.py
+++ b/bin/tests/test_design.py
@@ -190,7 +190,7 @@ class TestDesignFastaAligned(TestDesign.TestDesignCase):
         args = design.argv_to_args(argv)
         design.run(args)
         # Base args set the percentage of sequences to match at 75%
-        expected = [["AA"], ["CT"], ["CT"]]
+        expected = [["AA"], {("CT",), ("AC",)}, ["CT"]]
         self.check_results(self.real_output_file, expected)
 
     def test_max_activity(self):
@@ -208,7 +208,7 @@ class TestDesignFastaAligned(TestDesign.TestDesignCase):
         design.run(args)
         # Since sequences are short and need 1 base for primer on each side,
         # only finds 1 target in middle
-        expected = [["CT"]]
+        expected = [{("CT",), ("AC",)}]
         self.check_results(self.real_output_file, expected,
                            header='guide-target-sequences')
 
@@ -228,7 +228,7 @@ class TestDesignFastaAligned(TestDesign.TestDesignCase):
         design.run(args)
         # AA isn't allowed in 1st window by specificity fasta,
         # so 1st window changes
-        expected = [["AC", "GG"], ["CT"], ["CT"]]
+        expected = [{("AC", "GG"), ("AC",)}, {("CT",), ("AC",)}, ["CT"]]
         self.check_results(self.real_output_file, expected)
 
 
@@ -267,7 +267,7 @@ class TestDesignFastaUnaligned(TestDesign.TestDesignCase):
         args = design.argv_to_args(argv)
         design.run(args)
         # Base args set the percentage of sequences to match at 75%
-        expected = [["AA"], ["CT"], ["CT"]]
+        expected = [["AA"], {("CT",), ("AC",)}, ["CT"]]
         self.check_results(self.real_output_file, expected)
 
     def tearDown(self):
@@ -389,7 +389,7 @@ class TestDesignAutosFull(TestDesign.TestDesignCase):
         args = design.argv_to_args(argv)
         design.run(args)
         # Same output as test_specificity_fasta, as sequences are the same
-        expected = [["AC", "GG"], ["CT"], ["CT"]]
+        expected = [{("AC", "GG"), ("AC",)}, {("CT",), ("AC",)}, ["CT"]]
         self.check_results(self.real_output_file, expected)
 
     def tearDown(self):

--- a/bin/tests/test_design.py
+++ b/bin/tests/test_design.py
@@ -18,7 +18,8 @@ from bin import design
 __author__ = 'Priya Pillai <ppillai@broadinstitute.org>'
 
 # Default args: window size 3, guide size 2, allow GU pairing
-# GU pairing allows AA to match GG in 1st window
+# GU pairing allows AA to match GG in 1st window, and AC to
+# match GC in the 2nd window
 SEQS = OrderedDict()
 SEQS["genome_1"] = "AACTA"
 SEQS["genome_2"] = "AAACT"
@@ -62,7 +63,9 @@ class TestDesign(object):
             Args:
                 file: string, path name of the file
                 expected: list of lists of strings, all the expected guide
-                    target sequences in each line of the output
+                    target sequences in each line of the output; if an inner
+                    list is instead a set of lists, any of the lists in the
+                    set can be a correct output
                 header: the header of the CSV that contains the guide target
                     sequences
             """
@@ -75,11 +78,22 @@ class TestDesign(object):
                         col_loc = headers.index(header)
                         continue
                     self.assertLess(i, len(expected) + 1)
+                    ei = expected[i-1]
+                    if not isinstance(ei, set):
+                        ei = {tuple(ei)}
                     guide_line = line[:-1].split('\t')[col_loc]
                     guides = guide_line.split(' ')
-                    for guide in guides:
-                        self.assertIn(guide, expected[i-1])
-                    self.assertEqual(len(guides), len(expected[i-1]))
+                    an_option_is_ok = False
+                    for eij in ei:
+                        is_correct = True
+                        for guide in guides:
+                            if guide not in eij:
+                                is_correct = False
+                        if len(guides) != len(eij):
+                            is_correct = False
+                        if is_correct:
+                            an_option_is_ok = True
+                    self.assertTrue(an_option_is_ok)
                 self.assertEqual(i, len(expected))
 
         def baseArgv(self, search_type='sliding-window', input_type='fasta',
@@ -185,7 +199,7 @@ class TestDesignFastaAligned(TestDesign.TestDesignCase):
         design.run(args)
         # Doesn't use model, just greedy binary prediction with 0 mismatches
         # (so same outputs as min-guides)
-        expected = [["AA"], ["CT"], ["CT"]]
+        expected = [["AA"], {("CT",), ("AC",)}, ["CT"]]
         self.check_results(self.real_output_file, expected)
 
     def test_complete_targets(self):


### PR DESCRIPTION
There are two functions that propose candidate guides, from which guides in the output design are selected:

- [`alignment.determine_representative_guides()`](https://github.com/broadinstitute/adapt/blob/2e805a8c46367e15809ef77cd53e47589c2b2e10/adapt/alignment.py#L648). This is used with the maximize activity objective, to build the ground set for the combinatorial optimization algorithm.
- [`alignment.construct_guide()`](https://github.com/broadinstitute/adapt/blob/2e805a8c46367e15809ef77cd53e47589c2b2e10/adapt/alignment.py#L214). This is used with the minimize guides objective, to select, at each iteration of the set cover algorithm, the next most optimal guide for detecting the yet-to-be-detected sequences.

In both cases, determining candidate guides is effectively a heuristic and they are meant to encompass representative subsequences within a genomic window. More options could lead to a better solution but finding that solution would be less efficient. Prior to this PR, the candidate guide sequences came from subsequence clusters: _k_-mers (where _k_ is the guide length) at each length-_k_ site were clustered, and the guide sequences were the consensus of each cluster.

It is also possible that the consensus across all of the genome sequences at the length-_k_ site (or, specifically, all of the genome sequences under consideration) could be a reasonable candidate guide sequence. In some cases, it may result in better detection activity than the consensus of any individual cluster. Therefore, this PR adds that overall consensus as a candidate guide.

The change affects some unit tests—it may yield a different solution that is equally optimal to or more optimal than the solution required by the unit test. Thus, this PR also modifies several unit tests to allow those different solutions.