### PR TITLE
Add a thermodynamic primer mode to design.py

### DIFF
--- a/adapt/alignment.py
+++ b/adapt/alignment.py
@@ -372,7 +372,7 @@ class Alignment(SequenceList):
 
     def determine_representative_oligos(self, start, oligo_length,
         seqs_to_consider, clusterer, missing_threshold=1,
-        is_suitable_fns=[], required_flanking_seqs=(None, None),
+        pre_filter_fns=[], required_flanking_seqs=(None, None),
         include_overall_consensus=True):
         """Construct a set of oligos representative of the target sequences.
 
@@ -392,7 +392,7 @@ class Alignment(SequenceList):
             missing_threshold: do not construct representative sequences if
                 the fraction of sequences with missing data, at any position
                 in the target range, exceeds this threshold
-            is_suitable_fns: if set, the value of this argument is a list
+            pre_filter_fns: if set, the value of this argument is a list
                 of functions f(x) such that this will only construct a oligo x
                 for which each f(x) is True
             required_flanking_seqs: tuple (s5, s3) that specifies sequences
@@ -454,7 +454,7 @@ class Alignment(SequenceList):
                 # Skip this guide; all sequences at a position in the cluster
                 # under consideration are 'N'
                 return False
-            for is_suitable_fn in is_suitable_fns:
+            for is_suitable_fn in pre_filter_fns:
                 if is_suitable_fn(olg) is False:
                     # Skip this oligo/cluster
                     return False

--- a/adapt/guide_search.py
+++ b/adapt/guide_search.py
@@ -27,7 +27,6 @@ class GuideSearcher(search.OligoSearcher):
     This is a base class, with subclasses defining methods depending on the
     objective. It should not be used without subclassing, as it does not define
     all the positional arguments necessary for search.OligoSearcher.
-
     """
     def __init__(self, guide_length, **kwargs):
         """

--- a/adapt/primer_search.py
+++ b/adapt/primer_search.py
@@ -150,10 +150,11 @@ class PrimerSearcher(search.OligoSearcher):
                 window_size, hide_warnings=True):
             start, end, primers_in_cover = cover
             num_primers = len(primers_in_cover)
-            frac_bound = self.total_frac_bound(primers_in_cover)
             if self.obj_type == 'min':
+                frac_bound = self.total_frac_bound(primers_in_cover)
                 obj_value = self.obj_value(primers_in_cover)
             else:
+                frac_bound = self.total_frac_bound(start, end, primers_in_cover)
                 obj_value = self.obj_value(start, end, primers_in_cover)
 
             # Check constraints

--- a/adapt/primer_search.py
+++ b/adapt/primer_search.py
@@ -25,6 +25,7 @@ class PrimerResult:
             frac_bound: total fraction of all sequences bound by the primers
             primers_in_cover: set of primers that achieve the desired coverage
                  and is minimal at the site
+            obj_value: value to use to compare primer covers to each other
         """
         self.start = start
         self.num_primers = num_primers

--- a/adapt/target_search.py
+++ b/adapt/target_search.py
@@ -116,7 +116,7 @@ class TargetSearcher:
             right_primers = left_primers
         else:
             right_primers = list(self.rps.find_primers(
-            max_at_site=self.max_primers_at_site))
+                max_at_site=self.max_primers_at_site))
         min_j = 0
         for i in range(len(left_primers) - 1):
             p1 = left_primers[i]

--- a/adapt/target_search.py
+++ b/adapt/target_search.py
@@ -601,6 +601,7 @@ class TargetSearcher:
 
         # If the primer searcher uses the 'max' objective, this is using a
         # thermodynamic model for primers-output that information
+        primer_tm = False
         if self.lps.obj_type == 'max':
             primer_tm = True
 

--- a/adapt/target_search.py
+++ b/adapt/target_search.py
@@ -137,8 +137,8 @@ class TargetSearcher:
                 else:
                     skip_primers = False
                     for primer_set_filter in self.primer_set_filter_fns:
-                        if primer_set_filter({*p1.primers_in_cover,
-                                *p2.primers_in_cover}) is False:
+                        if primer_set_filter({*p1.primers_in_set,
+                                *p2.primers_in_set}) is False:
                             # Skip these primers
                             skip_primers = True
                             break
@@ -384,8 +384,8 @@ class TargetSearcher:
                 # instance of GuideSearcherMinimizeGuides (i.e., not for
                 # MaximizeActivity -- mostly for technical implementation
                 # reasons)
-                p1_bound_seqs = self.lps.seqs_bound(p1.primers_in_cover)
-                p2_bound_seqs = self.rps.seqs_bound(p2.primers_in_cover)
+                p1_bound_seqs = self.lps.seqs_bound(p1.primers_in_set)
+                p2_bound_seqs = self.rps.seqs_bound(p2.primers_in_set)
                 primer_bound_seqs = p1_bound_seqs & p2_bound_seqs
                 guide_seqs_to_consider = primer_bound_seqs
             else:
@@ -651,9 +651,9 @@ class TargetSearcher:
                 target_length = target_end - target_start
 
                 # Construct string of primers and guides
-                p1_seqs_sorted = sorted(list(p1.primers_in_cover))
+                p1_seqs_sorted = sorted(list(p1.primers_in_set))
                 p1_seqs_str = ' '.join(p1_seqs_sorted)
-                p2_seqs_sorted = sorted(list(p2.primers_in_cover))
+                p2_seqs_sorted = sorted(list(p2.primers_in_set))
                 p2_seqs_str = ' '.join(p2_seqs_sorted)
                 guides_seqs_sorted = sorted(list(guides))
                 guides_seqs_str = ' '.join(guides_seqs_sorted)

--- a/adapt/target_search.py
+++ b/adapt/target_search.py
@@ -25,10 +25,10 @@ logger = logging.getLogger(__name__)
 class TargetSearcher:
     """Methods to search for targets over a genome."""
 
-    def __init__(self, ps, gs, obj_type='min', max_primers_at_site=None,
+    def __init__(self, lps, rps, gs, obj_type='min', max_primers_at_site=None,
             max_target_length=None, obj_weights=None,
             only_account_for_amplified_seqs=False, halt_early=False,
-            obj_value_shift=None, mutator=None):
+            obj_value_shift=None, mutator=None, primer_set_filters=None):
         """
         Args:
             ps: PrimerSearcher object
@@ -65,12 +65,9 @@ class TargetSearcher:
             mutator: a adapt.utils.mutate Mutator object. If None (default),
                 do not predict activity after mutations.
         """
-        self.ps = ps
+        self.lps = lps
+        self.rps = rps
         self.gs = gs
-
-        if obj_type not in ['min', 'max']:
-            raise ValueError(("obj_type must be 'min' or 'max'"))
-        self.obj_type = obj_type
 
         self.max_primers_at_site = max_primers_at_site
         self.max_target_length = max_target_length if (max_target_length is not
@@ -103,26 +100,47 @@ class TargetSearcher:
                 self.obj_value_shift = 4.0
 
         self.mutator = mutator
+        self.primer_set_filters = primer_set_filters if primer_set_filters is not None else []
 
     def _find_primer_pairs(self):
-        """Find suitable primer pairs using self.ps.
+        """Find suitable primer pairs using self.lps and self.rps.
 
         Yields:
             tuple (p_i, p_j) where p_i is a tuple containing a
             primer_search.PrimerResult object, and likewise for p_j.
             The start position of p_j is > the start position of p_i.
         """
-        primers = list(self.ps.find_primers(
+        left_primers = list(self.lps.find_primers(
             max_at_site=self.max_primers_at_site))
-        for i in range(len(primers) - 1):
-            p1 = primers[i]
-            for j in range(i + 1, len(primers)):
-                p2 = primers[j]
+        if self.lps is self.rps:
+            right_primers = left_primers
+        else:
+            right_primers = list(self.rps.find_primers(
+            max_at_site=self.max_primers_at_site))
+        min_j = 0
+        for i in range(len(left_primers) - 1):
+            p1 = left_primers[i]
+            while (min_j < len(right_primers) and
+                   right_primers[min_j].start <= p1.start):
+                min_j += 1
+            if min_j >= len(right_primers):
+                break
+            for j in range(min_j, len(right_primers)):
+                p2 = right_primers[j]
                 target_length = p2.start + p2.primer_length - p1.start
                 if target_length > self.max_target_length:
                     # This is longer than allowed, so skip it and anything later
                     break
                 else:
+                    skip_primers = False
+                    for primer_set_filter in self.primer_set_filters:
+                        if primer_set_filter({*p1.primers_in_cover,
+                                *p2.primers_in_cover}) is False:
+                            # Skip these primers
+                            skip_primers = True
+                            break
+                    if skip_primers:
+                        continue
                     yield (p1, p2)
 
     def _find_mutated_activity(self, targets):
@@ -177,10 +195,10 @@ class TargetSearcher:
         # store each as a tuple ((+/-)obj_value, push_id, target)
         # The heap is a min heap, so popped values are the ones with
         # the smallest value in the first element
-        #   - When self.obj_type is 'min' we store -obj_value in the
+        #   - When self.gs.obj_type is 'min' we store -obj_value in the
         #     first element so that the one with the highest objective
         #     value (worst) is popped.
-        #   - When self.obj_type is 'max' we store +obj_value in
+        #   - When self.gs.obj_type is 'max' we store +obj_value in
         #     the first element so that the one with the smallest
         #     objective value (worst) is popped
         # In both cases, target_heap[0] refers to the target with the
@@ -192,22 +210,22 @@ class TargetSearcher:
         target_heap = []
         push_id_counter = itertools.count()
 
-        assert self.obj_type in ['min', 'max']
+        assert self.gs.obj_type in ['min', 'max']
         assert no_overlap in ['amplicon', 'primer', 'none']
         def obj_value(i):
             # Return objective value of the i'th element
-            if self.obj_type == 'min':
+            if self.gs.obj_type == 'min':
                 return -1 * target_heap[i][0]
-            elif self.obj_type == 'max':
+            elif self.gs.obj_type == 'max':
                 return target_heap[i][0]
 
         def obj_value_is_better(new, old):
             # Compare new objective value to old, and return True iff
             # new is better
-            if self.obj_type == 'min':
+            if self.gs.obj_type == 'min':
                 if new < old:
                     return True
-            elif self.obj_type == 'max':
+            elif self.gs.obj_type == 'max':
                 if new > old:
                     return True
             return False
@@ -254,9 +272,12 @@ class TargetSearcher:
             last_window_start = window_start
 
             # Calculate a cost of the primers
-            p1_num = p1.num_primers
-            p2_num = p2.num_primers
-            cost_primers = self.obj_weight_primers * (p1_num + p2_num)
+            p1_obj = p1.obj_value
+            p2_obj = p2.obj_value
+
+            cost_primers = self.obj_weight_primers * (p1_obj + p2_obj)
+            if self.lps.obj_type == 'max':
+                cost_primers *= -1
 
             # Calculate a cost of the window length
             cost_window = self.obj_weight_length * math.log2(window_length)
@@ -264,24 +285,24 @@ class TargetSearcher:
             # Calculate a best-case objective value for this target,
             # which can be done assuming a best-case for the guide search
             # This is useful for pruning the search
-            if self.obj_type == 'min':
+            if self.gs.obj_type == 'min':
                 best_possible_obj_value = (best_guide_obj_value +
                         cost_primers + cost_window)
-            elif self.obj_type == 'max':
+            elif self.gs.obj_type == 'max':
                 best_possible_obj_value = (best_guide_obj_value -
                         cost_primers - cost_window)
 
             # Check if we should bother trying to find guides in this window
             if len(target_heap) >= best_n:
                 curr_worst_obj_value = obj_value(0)
-                if self.obj_type == 'min':
+                if self.gs.obj_type == 'min':
                     if best_possible_obj_value >= curr_worst_obj_value:
                         # The objective value is already >= than all in the
                         # current best_n, and will only stay the same or get
                         # bigger after adding the term for guides, so there is
                         # no reason to continue considering this window
                         continue
-                elif self.obj_type == 'max':
+                elif self.gs.obj_type == 'max':
                     if best_possible_obj_value <= curr_worst_obj_value:
                         # The objective value is <= all in the current best_n
                         # even in the best-case outcome for the guide search,
@@ -357,8 +378,8 @@ class TargetSearcher:
                 # instance of GuideSearcherMinimizeGuides (i.e., not for
                 # MaximizeActivity -- mostly for technical implementation
                 # reasons)
-                p1_bound_seqs = self.ps.seqs_bound(p1.primers_in_cover)
-                p2_bound_seqs = self.ps.seqs_bound(p2.primers_in_cover)
+                p1_bound_seqs = self.lps.seqs_bound(p1.primers_in_cover)
+                p2_bound_seqs = self.rps.seqs_bound(p2.primers_in_cover)
                 primer_bound_seqs = p1_bound_seqs & p2_bound_seqs
                 guide_seqs_to_consider = primer_bound_seqs
             else:
@@ -408,8 +429,8 @@ class TargetSearcher:
                                 activities=activities)
             else:
                 # There is no predictor to predict activities
-                # This should only be the case if self.obj_type is 'min',
-                # and may not necessarily be the case if self.obj_type is
+                # This should only be the case if self.gs.obj_type is 'min',
+                # and may not necessarily be the case if self.gs.obj_type is
                 # 'min'
                 activities = None
                 guides_activity_expected = math.nan
@@ -426,11 +447,11 @@ class TargetSearcher:
                     guides_activity_median, guides_activity_5thpctile)
 
             # Calculate a total objective value
-            if self.obj_type == 'min':
+            if self.gs.obj_type == 'min':
                 obj_value_total = (self.gs.obj_value(guides) +
                         cost_primers + cost_window)
                 obj_value_to_add = -1 * obj_value_total
-            elif self.obj_type == 'max':
+            elif self.gs.obj_type == 'max':
                 gs_obj_value = self.gs.obj_value(window_start, window_end,
                         guides, activities=activities)
                 obj_value_total = (gs_obj_value -
@@ -504,7 +525,7 @@ class TargetSearcher:
         # In particular, sort by a 'sort_tuple' whose first element is
         # objective_value and then the target endpoints; it has the target
         # endpoints to break ties in objective value
-        if self.obj_type == 'min':
+        if self.gs.obj_type == 'min':
             r = [(-obj_value, target) for obj_value, push_id, target in target_heap]
             r_with_sort_tuple = []
             for (obj_value, target) in r:
@@ -514,7 +535,7 @@ class TargetSearcher:
                 sort_tuple = (obj_value, target_start)
                 r_with_sort_tuple += [(sort_tuple, obj_value, target)]
             r_with_sort_tuple = sorted(r_with_sort_tuple, key=lambda x: x[0])
-        elif self.obj_type == 'max':
+        elif self.gs.obj_type == 'max':
             r = [(obj_value, target) for obj_value, push_id, target in target_heap]
             r_with_sort_tuple = []
             for (obj_value, target) in r:
@@ -634,8 +655,8 @@ class TargetSearcher:
                              for gd_seq in guides_seqs_sorted]
                 else:
                     # There is no predictor to predict activities
-                    # This should only be the case if self.obj_type is 'min',
-                    # and may not necessarily be the case if self.obj_type is
+                    # This should only be the case if self.gs.obj_type is 'min',
+                    # and may not necessarily be the case if self.gs.obj_type is
                     # 'min'
                     expected_activities_per_guide = \
                             [math.nan for gd_seq in guides_seqs_sorted]

--- a/adapt/target_search.py
+++ b/adapt/target_search.py
@@ -14,7 +14,7 @@ import math
 import os
 import numpy as np
 
-from adapt.utils import search, thermo
+from adapt.utils import search, thermo, predict_activity
 from adapt import guide_search
 
 __author__ = 'Hayden Metsky <hayden@mit.edu>'
@@ -605,10 +605,9 @@ class TargetSearcher:
                         target_overlapping_annotations.append(annotation)
                 overlapping_annotations.append(target_overlapping_annotations)
 
-        # If the primer searcher uses the 'max' objective, this is using a
-        # thermodynamic model for primers-output that information
+        # If the primer predictor is for Tm-output thermodynamic information
         primer_tm = False
-        if self.lps.obj_type == 'max':
+        if isinstance(self.lps.predictor, predict_activity.TmPredictor):
             primer_tm = True
 
         with open(out_fn, 'w') as outf:
@@ -693,6 +692,8 @@ class TargetSearcher:
                             reverse_oligo=False,
                             conditions=self.rps.predictor.conditions) -
                         thermo.CELSIUS_TO_KELVIN for p2_seq in p2_seqs_sorted]
+                    # Note: the objective value for primers is the negative of
+                    # melting temperature variation with TmPredictor
                     line.extend([p1.start, p1.num_primers, p1_tm, -p1.obj_value,
                         p1.frac_bound, p1_seqs_str,
                         p2.start, p2.num_primers, p2_tm, -p2.obj_value,

--- a/adapt/tests/test_guide_search.py
+++ b/adapt/tests/test_guide_search.py
@@ -362,7 +362,7 @@ class TestGuideSearcherMinimizeGuides(unittest.TestCase):
         # It should be able to find a guide in a window without a gap
         self.i._find_oligos_in_window(10, 10 + self.i_window_size)
 
-    def test_is_suitable_fns(self):
+    def test_pre_filter_fns(self):
         seqs = ['GTATCAAAAAATCGGCTACCCCCTCTAC',
                 'CTACCAAAAAACCTGCTAGGGGGCGTAC',
                 'ATAGCAAAAAAACGTCCTCCCCCTGTAC',
@@ -381,7 +381,7 @@ class TestGuideSearcherMinimizeGuides(unittest.TestCase):
             else:
                 return True
         gs = guide_search.GuideSearcherMinimizeGuides(aln, 5, 0, 1.0, (1, 1, 100),
-            is_suitable_fns=[f])
+            pre_filter_fns=[f])
         self.assertEqual(gs._find_oligos_in_window(0, 28),
                          set(['CCCCC', 'GGGGG']))
 
@@ -621,12 +621,13 @@ class TestGuideSearcherMaximizeActivity(unittest.TestCase):
 
     def make_gs(self, seqs, soft_constraint=1, hard_constraint=3,
             penalty_strength=0.1, algorithm='random-greedy',
-            is_suitable_fns=[]):
+            pre_filter_fns=[]):
         # Predict guides matching target to have activity 1, and
         # starting with 'A' to have activity 2 (otherwise, 0)
         class PredictorTest:
             def __init__(self):
                 self.context_nt = 1
+                self.min_activity = 0
             def compute_activity(self, start_pos, pairs):
                 y = []
                 for target, guide_seq in pairs:
@@ -648,7 +649,7 @@ class TestGuideSearcherMaximizeActivity(unittest.TestCase):
                 soft_constraint, hard_constraint,
                 penalty_strength, (1, 1, 100), algorithm=algorithm,
                 predictor=predictor,
-                is_suitable_fns=is_suitable_fns)
+                pre_filter_fns=pre_filter_fns)
         return gs
 
     def test_obj_value_from_params(self):
@@ -919,7 +920,7 @@ class TestGuideSearcherMaximizeActivity(unittest.TestCase):
     def test_find_oligos_in_window_high_penalty_random_greedy(self):
         self.find_oligos_in_window_high_penalty('random-greedy')
 
-    def find_oligos_in_window_with_is_suitable_fns(self, algo):
+    def find_oligos_in_window_with_pre_filter_fns(self, algo):
         def f(guide):
             if 'AA' in guide:
                 return False
@@ -932,16 +933,16 @@ class TestGuideSearcherMaximizeActivity(unittest.TestCase):
                            'AACGAATTCG'],
                            hard_constraint=1,
                            algorithm=algo,
-                           is_suitable_fns=[f])
+                           pre_filter_fns=[f])
         o = gs._find_oligos_in_window(2, 8)
         self.assertEqual(len(o), 1)
         self.assertIn(list(o)[0], {'CGAA', 'GAAT', 'GGGG', 'CCCC'})
 
-    def test_find_oligos_in_window_with_is_suitable_fns_greedy(self):
-        self.find_oligos_in_window_with_is_suitable_fns('greedy')
+    def test_find_oligos_in_window_with_pre_filter_fns_greedy(self):
+        self.find_oligos_in_window_with_pre_filter_fns('greedy')
 
-    def test_find_oligos_in_window_with_is_suitable_fns_random_greedy(self):
-        self.find_oligos_in_window_with_is_suitable_fns('random-greedy')
+    def test_find_oligos_in_window_with_pre_filter_fns_random_greedy(self):
+        self.find_oligos_in_window_with_pre_filter_fns('random-greedy')
 
     def find_oligos_in_window_with_gaps_and_missing_data(self, algo):
         gs = self.make_gs(['ATCGAATTCG',

--- a/adapt/tests/test_primer_search.py
+++ b/adapt/tests/test_primer_search.py
@@ -16,56 +16,56 @@ class TestPrimerResult(unittest.TestCase):
     """
 
     def test_does_overlap(self):
-        a = primer_search.PrimerResult(10, 1, 5, 1.0, {'AAAAA'})
+        a = primer_search.PrimerResult(10, 1, 5, 1.0, {'AAAAA'}, 1)
         self.assertTrue(a.overlaps(a))
 
-        b = primer_search.PrimerResult(12, 1, 5, 1.0, {'AAAAA'})
+        b = primer_search.PrimerResult(12, 1, 5, 1.0, {'AAAAA'}, 1)
         self.assertTrue(a.overlaps(b))
         self.assertTrue(b.overlaps(a))
 
     def test_does_not_overlap(self):
-        a = primer_search.PrimerResult(10, 1, 5, 1.0, {'AAAAA'})
-        b = primer_search.PrimerResult(15, 1, 5, 1.0, {'AAAAA'})
-        c = primer_search.PrimerResult(16, 1, 5, 1.0, {'AAAAA'})
+        a = primer_search.PrimerResult(10, 1, 5, 1.0, {'AAAAA'}, 1)
+        b = primer_search.PrimerResult(15, 1, 5, 1.0, {'AAAAA'}, 1)
+        c = primer_search.PrimerResult(16, 1, 5, 1.0, {'AAAAA'}, 1)
         self.assertFalse(a.overlaps(b))
         self.assertFalse(b.overlaps(a))
         self.assertFalse(a.overlaps(c))
         self.assertFalse(c.overlaps(a))
 
     def test_does_overlap_with_expand(self):
-        a = primer_search.PrimerResult(10, 1, 5, 1.0, {'AAAAA'})
+        a = primer_search.PrimerResult(10, 1, 5, 1.0, {'AAAAA'}, 1)
         self.assertTrue(a.overlaps(a, expand=5))
 
-        b = primer_search.PrimerResult(12, 1, 5, 1.0, {'AAAAA'})
+        b = primer_search.PrimerResult(12, 1, 5, 1.0, {'AAAAA'}, 1)
         self.assertTrue(a.overlaps(b, expand=5))
         self.assertTrue(b.overlaps(a, expand=5))
 
-        b = primer_search.PrimerResult(17, 1, 5, 1.0, {'AAAAA'})
+        b = primer_search.PrimerResult(17, 1, 5, 1.0, {'AAAAA'}, 1)
         self.assertTrue(a.overlaps(b, expand=5))
         self.assertTrue(b.overlaps(a, expand=5))
 
-        c = primer_search.PrimerResult(2, 1, 5, 1.0, {'AAAAA'})
+        c = primer_search.PrimerResult(2, 1, 5, 1.0, {'AAAAA'}, 1)
         self.assertTrue(a.overlaps(c, expand=5))
         self.assertTrue(c.overlaps(a, expand=5))
 
     def test_does_not_overlap_with_expand(self):
-        a = primer_search.PrimerResult(10, 1, 5, 1.0, {'AAAAA'})
-        b = primer_search.PrimerResult(20, 1, 5, 1.0, {'AAAAA'})
-        c = primer_search.PrimerResult(0, 1, 5, 1.0, {'AAAAA'})
+        a = primer_search.PrimerResult(10, 1, 5, 1.0, {'AAAAA'}, 1)
+        b = primer_search.PrimerResult(20, 1, 5, 1.0, {'AAAAA'}, 1)
+        c = primer_search.PrimerResult(0, 1, 5, 1.0, {'AAAAA'}, 1)
         self.assertFalse(a.overlaps(b, expand=5))
         self.assertFalse(b.overlaps(a, expand=5))
         self.assertFalse(a.overlaps(c, expand=5))
         self.assertFalse(c.overlaps(a, expand=5))
 
     def test_does_overlap_range(self):
-        a = primer_search.PrimerResult(10, 1, 5, 1.0, {'AAAAA'})
+        a = primer_search.PrimerResult(10, 1, 5, 1.0, {'AAAAA'}, 1)
         self.assertTrue(a.overlaps_range(5, 20))
         self.assertTrue(a.overlaps_range(5, 12))
         self.assertTrue(a.overlaps_range(12, 20))
         self.assertTrue(a.overlaps_range(11, 13))
 
     def test_does_not_overlap_range(self):
-        a = primer_search.PrimerResult(10, 1, 5, 1.0, {'AAAAA'})
+        a = primer_search.PrimerResult(10, 1, 5, 1.0, {'AAAAA'}, 1)
         self.assertFalse(a.overlaps_range(2, 8))
         self.assertFalse(a.overlaps_range(20, 25))
 
@@ -94,7 +94,7 @@ class TestPrimerSearch(unittest.TestCase):
     def _pr(self, start, num_primers, frac_bound, primers_in_cover):
         # Construct a PrimerResult object
         return primer_search.PrimerResult(start, num_primers, 4, frac_bound,
-            primers_in_cover)
+            primers_in_cover, num_primers)
 
     def test_find_primers_simple(self):
         covers = list(self.a.find_primers())

--- a/adapt/tests/test_primer_search.py
+++ b/adapt/tests/test_primer_search.py
@@ -91,10 +91,10 @@ class TestPrimerSearch(unittest.TestCase):
         self.a_gc_bounds = primer_search.PrimerSearcherMinimizePrimers(self.a_aln,
                 4, 0, 1.0, (1, 1, 100), primer_gc_content_bounds=(0.4, 0.6))
 
-    def _pr(self, start, num_primers, frac_bound, primers_in_cover):
+    def _pr(self, start, num_primers, frac_bound, primers_in_set):
         # Construct a PrimerResult object
         return primer_search.PrimerResult(start, num_primers, 4, frac_bound,
-            primers_in_cover, num_primers)
+            primers_in_set, num_primers)
 
     def test_find_primers_simple(self):
         covers = list(self.a.find_primers())

--- a/adapt/tests/test_target_search.py
+++ b/adapt/tests/test_target_search.py
@@ -35,7 +35,7 @@ class TestTargetSearch(unittest.TestCase):
 
         a_min_gs = guide_search.GuideSearcherMinimizeGuides(
             self.a_aln, 6, 0, 1.0, (1, 1, 100))
-        self.a_min = target_search.TargetSearcher(a_ps, a_min_gs, obj_type='min',
+        self.a_min = target_search.TargetSearcher(a_ps, a_ps, a_min_gs,
             max_primers_at_site=2)
 
     def test_find_primer_pairs_simple_minimize(self):
@@ -173,7 +173,7 @@ class TestTargetSearch(unittest.TestCase):
             b_aln, 4, 0, cover_frac, (1, 1, 100), seq_groups=seq_groups)
         b_gs = guide_search.GuideSearcherMinimizeGuides(
             b_aln, 6, 0, cover_frac, (1, 1, 100), seq_groups=seq_groups)
-        b = target_search.TargetSearcher(b_ps, b_gs, obj_type='min',
+        b = target_search.TargetSearcher(b_ps, b_ps, b_gs,
             max_primers_at_site=2)
 
         for best_n in [1, 2, 3, 4, 5, 6]:
@@ -208,6 +208,7 @@ class TestTargetSearch(unittest.TestCase):
             def __init__(self):
                 self.context_nt = 1
                 self.rough_max_activity = 3
+                self.min_activity = 0
             def compute_activity(self, start_pos, pairs):
                 y = []
                 for target, guide in pairs:
@@ -241,7 +242,7 @@ class TestTargetSearch(unittest.TestCase):
         a_max_gs.guide_clusterer = alignment.SequenceClusterer(
                 lsh.HammingDistanceFamily(6), k=6)
 
-        a_max = target_search.TargetSearcher(a_ps, a_max_gs, obj_type='max',
+        a_max = target_search.TargetSearcher(a_ps, a_ps, a_max_gs,
             max_primers_at_site=2)
 
         for best_n in [1, 2, 3, 4, 5, 6]:
@@ -348,8 +349,8 @@ class TestTargetSearch(unittest.TestCase):
         c_gs = guide_search.GuideSearcherMaximizeActivity(
                     self.a_aln, 6, 1, 5, 0.05, (1, 1, 100), algorithm='greedy',
                     predictor=predictor)
-        c = target_search.TargetSearcher(c_ps, c_gs, max_primers_at_site=2,
-                                         obj_type='max', mutator=mutator)
+        c = target_search.TargetSearcher(c_ps, c_ps, c_gs,
+                max_primers_at_site=2, mutator=mutator)
         for best_n in [1, 2, 3, 4, 5, 6]:
             targets = c.find_targets(best_n=best_n, no_overlap='none')
             mut_activities = c._find_mutated_activity(targets)

--- a/adapt/tests/test_target_search.py
+++ b/adapt/tests/test_target_search.py
@@ -59,7 +59,7 @@ class TestTargetSearch(unittest.TestCase):
             # Verify that the primer sequences are in the alignment
             # at their given locations
             for p in (p1, p2):
-                for primer in p.primers_in_cover:
+                for primer in p.primers_in_set:
                     in_aln = False
                     for seq in self.a_seqs:
                         if primer == seq[p.start:(p.start + 4)]:

--- a/adapt/utils/predict_activity.py
+++ b/adapt/utils/predict_activity.py
@@ -487,9 +487,7 @@ class TmPredictor:
             if self.key_fn(pair) not in mem:
                 mem[self.key_fn(pair)] = [-abs(thermo.calculate_melting_temp(
                     pair[0], pair[1], self.reverse,
-                    self.conditions.sodium, self.conditions.magnesium,
-                    self.conditions.dNTP, self.conditions.oligo_concentration,
-                    self.conditions.target_concentration) - self.ideal_tm)]
+                    self.conditions) - self.ideal_tm)]
 
     def cleanup_memoized(self, start_pos):
         """Cleanup memoizations no longer needed at a start position.

--- a/adapt/utils/predict_activity.py
+++ b/adapt/utils/predict_activity.py
@@ -444,7 +444,7 @@ class TmPredictor:
 
         self.key_fn = key_fn
 
-        self.min_activity = -max_delta_tm
+        self.min_activity = -self.ideal_tm
 
     def compute_activity(self, start_pos, pairs):
         """Compute a single activity measurement for pairs.

--- a/adapt/utils/search.py
+++ b/adapt/utils/search.py
@@ -170,7 +170,6 @@ class OligoSearcher:
 
         if start in inner_dict:
             # The result has been memoized
-
             p_memoized = inner_dict[start]
 
             # p was compressed before memoizing it; decompress
@@ -181,7 +180,6 @@ class OligoSearcher:
                 p = self._decompress_result(p_memoized)
         else:
             # The result is not memoized; compute it and memoize it
-
             p = call_fn()
 
             if p is None:
@@ -1871,7 +1869,8 @@ class OligoSearcherMaximizeActivity(OligoSearcher):
         # Initialize an empty oligo set, with 0 activity against each
         # target sequence
         curr_oligo_set = set()
-        curr_activities = np.zeros(self.aln.num_sequences)
+        curr_activities = np.full(self.aln.num_sequences,
+            self.predictor.min_activity)
 
         def add_oligo(olg, olg_pos, olg_activities):
             # Add olg into curr_oligo_set and update curr_activities

--- a/adapt/utils/search.py
+++ b/adapt/utils/search.py
@@ -29,10 +29,10 @@ class OligoSearcher:
     """
 
     def __init__(self, aln, min_oligo_length, max_oligo_length,
-            missing_data_params, is_suitable_fns=[], required_oligos={},
-            ignored_ranges={}, allow_gu_pairs=False,
-            required_flanking_seqs=(None, None), do_not_memoize=False,
-            predictor=None):
+            missing_data_params, obj_type, pre_filter_fns=None,
+            post_filter_fns=None, required_oligos=None, ignored_ranges=None,
+            allow_gu_pairs=False, required_flanking_seqs=(None, None),
+            do_not_memoize=False, predictor=None):
         """
         Args:
             aln: alignment.Alignment representing an alignment of sequences
@@ -43,7 +43,7 @@ class OligoSearcher:
                 sequences with missing data is > min(a, max(b, c*m)), where m is
                 the median fraction of sequences with missing data over the
                 alignment
-            is_suitable_fns: if set, the value of this argument is a list
+            pre_filter_fns: if set, the value of this argument is a list
                 of functions f(x) such that this will only construct a oligo x
                 for which each f(x) is True
             required_oligos: dict that maps oligo sequences to their position
@@ -96,9 +96,14 @@ class OligoSearcher:
         self.missing_threshold = min(missing_max, max(missing_min,
             missing_coeff * self.aln.median_sequences_with_missing_data()))
 
-        self.is_suitable_fns = is_suitable_fns
+        if obj_type not in ['min', 'max']:
+            raise ValueError(("obj_type must be 'min' or 'max'"))
+        self.obj_type = obj_type
 
-        self.required_oligos = required_oligos
+        self.pre_filter_fns = pre_filter_fns if pre_filter_fns is not None else []
+        self.post_filter_fns = post_filter_fns if post_filter_fns is not None else []
+        self.required_oligos = required_oligos if required_oligos is not None else {}
+        self.ignored_ranges = ignored_ranges if ignored_ranges is not None else {}
 
         # Verify positions of the oligos are within the alignment
         highest_possible_pos = self.aln.seq_length - self.min_oligo_length
@@ -113,10 +118,8 @@ class OligoSearcher:
         # memoize them
         self._memoized_seqs_covered_by_required_oligos = {}
 
-        self.ignored_ranges = ignored_ranges
-
         # Verify ignored ranges are within the alignment
-        for start, end in ignored_ranges:
+        for start, end in self.ignored_ranges:
             if start < 0 or end <= start or end > self.aln.seq_length:
                 raise Exception(("An ignored range [%d, %d) is invalid "
                     "for a given alignment; ranges must fall within the "
@@ -680,7 +683,7 @@ class OligoSearcherMinimizeNumber(OligoSearcher):
         """
         self.mismatches = mismatches
 
-        super().__init__(**kwargs)
+        super().__init__(obj_type='min', **kwargs)
 
         if seq_groups is None and (cover_frac <= 0 or cover_frac > 1):
             raise ValueError("cover_frac must be in (0,1]")
@@ -1433,7 +1436,7 @@ class OligoSearcherMinimizeNumber(OligoSearcher):
                 # are 'N'
                 continue
             skip_cluster = False
-            for is_suitable_fn in self.is_suitable_fns:
+            for is_suitable_fn in self.pre_filter_fns:
                 if is_suitable_fn(olg) is False:
                     # Skip this cluster
                     skip_cluster = True
@@ -1446,6 +1449,13 @@ class OligoSearcherMinimizeNumber(OligoSearcher):
                     determine_binding_and_active_seqs(olg)
             score = seq_idxs_score(binding_seqs)
             if score > best_olg_score:
+                for is_suitable_fn in self.post_filter_fns:
+                    if is_suitable_fn(olg) is False:
+                        # Skip this cluster
+                        skip_cluster = True
+                        break
+                if skip_cluster:
+                    continue
                 best_olg = olg
                 best_olg_binding_seqs = binding_seqs
                 best_olg_score = score
@@ -1481,7 +1491,7 @@ class OligoSearcherMinimizeNumber(OligoSearcher):
                     # s has ambiguity; skip it
                     continue
                 skip_cluster = False
-                for is_suitable_fn in self.is_suitable_fns:
+                for is_suitable_fn in self.pre_filter_fns:
                     if is_suitable_fn(s) is False:
                         # Skip this cluster
                         skip_cluster = True
@@ -1494,6 +1504,13 @@ class OligoSearcherMinimizeNumber(OligoSearcher):
                             [(s_with_context, s)])[0]:
                         # s is not active against itself; skip it
                         continue
+                for is_suitable_fn in self.post_filter_fns:
+                    if is_suitable_fn(s) is False:
+                        # Skip this cluster
+                        skip_cluster = True
+                        break
+                if skip_cluster:
+                    continue
                 # s has no ambiguity and is a suitable oligo; use it
                 olg = s
                 binding_seqs, _, _ = determine_binding_and_active_seqs(olg)
@@ -1563,7 +1580,7 @@ class OligoSearcherMaximizeActivity(OligoSearcher):
         # memoize the ground set of oligos at each site
         self._memoized_ground_sets = {}
 
-        super().__init__(**kwargs)
+        super().__init__(obj_type='max', **kwargs)
 
     def _obj_value_from_params(self, expected_activity, num_oligos):
         """Compute value of objective function from parameter values.
@@ -1968,9 +1985,10 @@ class OligoSearcherMaximizeActivity(OligoSearcher):
             activities = self.oligo_set_activities(window_start, window_end,
                     oligo_set)
 
-        # Calculate weighted fraction of activity values >0
+        # Calculate weighted fraction of activity values >min_activity
         frac_active = sum(self.aln.seq_norm_weights[i]
-                         for i, x in enumerate(activities) if x > 0)
+                         for i, x in enumerate(activities)
+                         if x > self.predictor.min_activity)
 
         return frac_active
 
@@ -2040,7 +2058,7 @@ class OligoSearcherMaximizeActivity(OligoSearcher):
             ground_set = self.aln.determine_representative_oligos(
                     start, max_oligo_length, seqs_to_consider,
                     self.clusterer, missing_threshold=self.missing_threshold,
-                    is_suitable_fns=self.is_suitable_fns,
+                    pre_filter_fns=self.pre_filter_fns,
                     required_flanking_seqs=self.required_flanking_seqs)
         except CannotConstructOligoError:
             # There may be too much missing data or a related issue
@@ -2081,6 +2099,14 @@ class OligoSearcherMaximizeActivity(OligoSearcher):
                         continue
                 # Chooses smallest oligo when tied; make a setting?
                 if expected_activity > best_expected_activity:
+                    skip_olg = False
+                    for is_suitable_fn in self.post_filter_fns:
+                        if is_suitable_fn(short_olg_seq) is False:
+                            # Skip this oligo
+                            skip_olg = True
+                            break
+                    if skip_olg:
+                        continue
                     best_seq = olg_seq[:oligo_length]
                     best_activities = activities
                     best_expected_activity = expected_activity

--- a/adapt/utils/search.py
+++ b/adapt/utils/search.py
@@ -45,7 +45,12 @@ class OligoSearcher:
                 alignment
             pre_filter_fns: if set, the value of this argument is a list
                 of functions f(x) such that this will only construct a oligo x
-                for which each f(x) is True
+                for which each f(x) is True. These filters run before activity
+                is calculated.
+            post_filter_fns: if set, the value of this argument is a list
+                of functions f(x) such that this will only construct a oligo x
+                for which each f(x) is True. These filters run after activity
+                is calculated and determined to be good.
             required_oligos: dict that maps oligo sequences to their position
                 in the alignment; all of these oligo sequences are immediately
                 placed in the set of covering oligos for their appropriate

--- a/adapt/utils/tests/test_predict_activity.py
+++ b/adapt/utils/tests/test_predict_activity.py
@@ -319,9 +319,9 @@ class TestTmPredictor(unittest.TestCase):
         conditions = thermo.Conditions(sodium=1, magnesium=0, dNTP=0,
             oligo_concentration=1)
         shared_memo = {}
-        left_predictor = predict_activity.TmPredictor(PERFECT_TM, 0.5,
+        left_predictor = predict_activity.TmPredictor(PERFECT_TM,
             conditions, False, shared_memo=shared_memo)
-        right_predictor = predict_activity.TmPredictor(PERFECT_TM, 0.5,
+        right_predictor = predict_activity.TmPredictor(PERFECT_TM,
             conditions, True, shared_memo=shared_memo)
         activities = left_predictor.compute_activity(0, pairs)
         expected = np.array([0, 0, -PERFECT_TM, 0, -20, -PERFECT_TM])

--- a/adapt/utils/tests/test_search.py
+++ b/adapt/utils/tests/test_search.py
@@ -391,7 +391,7 @@ class TestOligoSearcher(unittest.TestCase):
         self.assertEqual(olg_seqs, {0,2,3})
         self.assertAlmostEqual(score, .75)
 
-        # Only predict oligos starting with 'A' to be active
+        # Only predict oligos starting with start_base to be active
         class PredictorTest:
             def __init__(self, start_base):
                 self.context_nt = 0

--- a/adapt/utils/tests/test_thermo.py
+++ b/adapt/utils/tests/test_thermo.py
@@ -51,12 +51,6 @@ FAKE_DNA_DNA_TERM_AT = (5, 0.1)
 FAKE_DNA_DNA_SALT = (0, 0.0)
 FAKE_R_CONSTANT = 1/np.log(4)
 
-# # With 2 bp matching, delta H is 20 and delta S is 0.1. With the thermodynamic
-# # conditions set to not interfere, the melting temperature is delta H/delta S,
-# # which is 200K (Note: this doesn't actually make sense in practice, as Tm
-# # can't go below 0°C; this is a toy example to make testing easier)
-# PERFECT_TM = 200 - thermo.CELSIUS_TO_KELVIN
-
 
 class TestThermo(object):
     """General class for testing analyze_coverage.py

--- a/adapt/utils/tests/test_thermo.py
+++ b/adapt/utils/tests/test_thermo.py
@@ -117,7 +117,7 @@ class TestThermoCases(TestThermo.TestThermoCase):
         #    + (2 terminal AT bases * 5) = 32
         # s = (2 XA/XT base * 0.05) + (1 XC/XA bases * 0.01)
         #    + (2 terminal AT bases * 0.1) = 0.31
-        h,s = thermo.calculate_delta_h_s('AAAC','AAAT')
+        h,s = thermo.calculate_delta_h_s('AAAT','AAAC')
         self.assertEqual(h, 32)
         self.assertAlmostEqual(s, 0.31)
         # Reverse oligo false
@@ -125,7 +125,7 @@ class TestThermoCases(TestThermo.TestThermoCase):
         #    + (2 terminal AT bases * 5) = 31
         # s = (2 XA/XT base * 0.05) + (1 XT/XG bases * 0.005)
         #    + (2 terminal AT bases * 0.1) = 0.305
-        h,s = thermo.calculate_delta_h_s('AAAC','AAAT', reverse_oligo=False)
+        h,s = thermo.calculate_delta_h_s('AAAT','AAAC', reverse_oligo=False)
         self.assertEqual(h, 31)
         self.assertAlmostEqual(s, 0.305)
         # Symmetric

--- a/adapt/utils/thermo.py
+++ b/adapt/utils/thermo.py
@@ -475,6 +475,18 @@ DNA_DNA_TERMINAL = {
 # kcal/mol K
 R_CONSTANT = .001987
 
+
+class Conditions:
+    """docstring for PCRConditions"""
+    def __init__(self, sodium=5e-2, magnesium=0, dNTP=0,
+        oligo_concentration=3e-7, target_concentration=0):
+        self.sodium = sodium
+        self.magnesium = magnesium
+        self.dNTP = dNTP
+        self.oligo_concentration = oligo_concentration
+        self.target_concentration = target_concentration
+
+
 def _delta_g_from_h_s(h, s, t=310.15):
     """Get free energy from enthalpy and entropy
 

--- a/adapt/utils/thermo.py
+++ b/adapt/utils/thermo.py
@@ -504,11 +504,11 @@ def calculate_melting_temp(oligo, target, reverse_oligo=True,
     """
     try:
         if saltmethod=='santalucia':
-            h,s = calculate_delta_h_s(target, oligo,
+            h,s = calculate_delta_h_s(oligo, target,
                                       reverse_oligo=reverse_oligo,
                                       conditions=conditions)
         else:
-            h,s = calculate_delta_h_s(target, oligo,
+            h,s = calculate_delta_h_s(oligo, target,
                                       reverse_oligo=reverse_oligo,
                                       conditions=Conditions(
                                         sodium=1, magnesium=0, dNTP=0))
@@ -609,12 +609,12 @@ def calculate_equilibrium_constant(oligo, target, reverse_oligo=True,
     Returns:
         Equilibrium constant
     """
-    delta_g = calculate_delta_g(target, oligo, reverse_oligo=reverse_oligo,
+    delta_g = calculate_delta_g(oligo, target, reverse_oligo=reverse_oligo,
         conditions=conditions)
     return math.e**(-delta_g/(R_CONSTANT*conditions.t))
 
 
-def calculate_delta_g(target, oligo, reverse_oligo=True,
+def calculate_delta_g(oligo, target, reverse_oligo=True,
         conditions=Conditions()):
     """Calculate free energy of the target and oligo annealing
 
@@ -636,13 +636,13 @@ def calculate_delta_g(target, oligo, reverse_oligo=True,
         Free energy in kcal/mol
     """
 
-    h,s = calculate_delta_h_s(target, oligo, reverse_oligo=reverse_oligo,
+    h,s = calculate_delta_h_s(oligo, target, reverse_oligo=reverse_oligo,
                               conditions=conditions)
 
     return _delta_g_from_h_s(h, s, t=conditions.t)
 
 
-def calculate_delta_h_s(target, oligo, reverse_oligo=True,
+def calculate_delta_h_s(oligo, target, reverse_oligo=True,
         conditions=Conditions()):
     """Calculate enthalpy and entropy of the target and oligo annealing
 

--- a/bin/design.py
+++ b/bin/design.py
@@ -828,11 +828,11 @@ def design_for_id(args):
                     oligo_concentration=args.oligo_conc,
                     target_concentration=args.target_conc)
                 left_primer_predictor = predict_activity.TmPredictor(
-                    args.ideal_primer_melting_temperature,
+                    args.ideal_primer_melting_temperature + 273.15,
                     args.primer_melting_temperature_variation,
                     conditions, False, shared_memo=shared_memo)
                 right_primer_predictor = predict_activity.TmPredictor(
-                    args.ideal_primer_melting_temperature,
+                    args.ideal_primer_melting_temperature + 273.15,
                     args.primer_melting_temperature_variation,
                     conditions, True, shared_memo=shared_memo)
 
@@ -860,7 +860,7 @@ def design_for_id(args):
                     aln, args.primer_length, args.primer_length,
                     args.soft_primer_constraint, args.hard_primer_constraint,
                     args.primer_penalty_strength, args.missing_thres,
-                    algorithm=args.maximization_algorithm,
+                    algorithm='greedy',
                     primer_gc_content_bounds=primer_gc_content_bounds,
                     post_filter_fns=post_filter_primers,
                     predictor=left_primer_predictor)
@@ -868,7 +868,7 @@ def design_for_id(args):
                     aln, args.primer_length, args.primer_length,
                     args.soft_primer_constraint, args.hard_primer_constraint,
                     args.primer_penalty_strength, args.missing_thres,
-                    algorithm=args.maximization_algorithm,
+                    algorithm='greedy',
                     primer_gc_content_bounds=primer_gc_content_bounds,
                     post_filter_fns=post_filter_primers,
                     predictor=right_primer_predictor)

--- a/bin/design.py
+++ b/bin/design.py
@@ -823,16 +823,18 @@ def design_for_id(args):
                 primer_gc_content_bounds = tuple(args.primer_gc_content_bounds)
             if args.primer_thermo:
                 shared_memo = {}
-                conditions = thermo.Conditions(sodium=args.sodium_conc,
-                    magnesium=args.magnesium_conc, dNTP=args.dntp_conc,
-                    oligo_concentration=args.oligo_conc,
-                    target_concentration=args.target_conc)
+                conditions = thermo.Conditions(sodium=args.pcr_sodium_conc,
+                    magnesium=args.pcr_magnesium_conc, dNTP=args.pcr_dntp_conc,
+                    oligo_concentration=args.pcr_oligo_conc,
+                    target_concentration=args.pcr_target_conc)
                 left_primer_predictor = predict_activity.TmPredictor(
-                    args.ideal_primer_melting_temperature + 273.15,
+                    args.ideal_primer_melting_temperature +
+                        thermo.CELSIUS_TO_KELVIN,
                     args.primer_melting_temperature_variation,
                     conditions, False, shared_memo=shared_memo)
                 right_primer_predictor = predict_activity.TmPredictor(
-                    args.ideal_primer_melting_temperature + 273.15,
+                    args.ideal_primer_melting_temperature +
+                        thermo.CELSIUS_TO_KELVIN,
                     args.primer_melting_temperature_variation,
                     conditions, True, shared_memo=shared_memo)
 
@@ -1378,17 +1380,16 @@ def argv_to_args(argv):
     #           "PRIMER_TERMINAL_MISMATCHES is set."))
     parser_ct_args.add_argument('-pt', '--primer-thermo',
         action='store_true',
-        help=("If set, in addition to using mismatches, use a thermodynamic "
-              "model to determine whether primers cover a sequence. This is "
-              "particularly useful for PCR primers."))
+        help=("If set, use a thermodynamic model to determine whether primers "
+              "cover a sequence. This is particularly useful for PCR."))
     parser_ct_args.add_argument('--ideal-primer-melting-temperature',
-        type=int, default=60,
+        type=float, default=60,
         help=("Allow for at most PRIMER_MELTING_TEMPERATURE_VARIATION°C "
               "deviation from the perfect match primer's melting temperature "
               "for a sequence to be considered 'bound' still."
               "Default is 60°C. Only used if --primer-thermo is set."))
     parser_ct_args.add_argument('--primer-melting-temperature-variation',
-        type=int, default=20,
+        type=float, default=20,
         help=("Allow for at most PRIMER_MELTING_TEMPERATURE_VARIATION°C "
               "deviation from the perfect match primer's melting temperature "
               "for a sequence to be considered 'bound' still."
@@ -1408,7 +1409,7 @@ def argv_to_args(argv):
         help=("Hard constraint on the number of primers. The number of "
               "primers designed for a target will be <= "
               "HARD_PRIMER_CONSTRAINT."))
-    # Penalty strength TODO what are reasonable values really
+    # Penalty strength TODO find reasonable values experimentally
     base_subparser.add_argument('--primer-penalty-strength', type=float,
         default=0.25,
         help=("Importance of the penalty when the number of primer "
@@ -1419,25 +1420,30 @@ def argv_to_args(argv):
               "Reasonable values are in the range [0.1, 0.5]."))
 
     # Set thermodynamic conditions
-    parser_ct_args.add_argument('-na', '--sodium-conc', type=float, default=5e-2,
+    parser_ct_args.add_argument('-na', '--pcr-sodium-conc', type=float,
+        default=5e-2,
         help=("Concentration of sodium (in mol/L). Can be used for the "
               "concentration of all monovalent cations. Only used if "
               "--primer-thermo or --guide-thermo is set. Defaults to "
               "0.050 mol/L."))
-    parser_ct_args.add_argument('-mg', '--magnesium-conc', type=float, default=2.5e-3,
+    parser_ct_args.add_argument('-mg', '--pcr-magnesium-conc', type=float,
+        default=2.5e-3,
         help=("Concentration of magnesium (in mol/L). Can be used for the "
               "concentration of all divalent cations. Only used if "
               "--primer-thermo or --guide-thermo is set. Defaults to "
               "0.0025 mol/L."))
-    parser_ct_args.add_argument('--dntp-conc', type=float, default=1.6e-3,
+    parser_ct_args.add_argument('--pcr-dntp-conc', type=float,
+        default=1.6e-3,
         help=("Concentration of dNTPs (in mol/L). Only used if "
               "--primer-thermo or --guide-thermo is set. Defaults to "
               "0.0016 mol/L."))
-    parser_ct_args.add_argument('--oligo-conc', type=float, default=3e-7,
+    parser_ct_args.add_argument('--pcr-oligo-conc', type=float,
+        default=3e-7,
         help=("Oligo concentration (in mol/L). Only used if "
               "--primer-thermo or --guide-thermo is set. Defaults to "
               "3e-7 mol/L."))
-    parser_ct_args.add_argument('--target-conc', type=float, default=0,
+    parser_ct_args.add_argument('--pcr-target-conc', type=float,
+        default=0,
         help=("Target concentration (in mol/L). Only used if "
               "--primer-thermo or --guide-thermo is set; only needed if "
               "target concentration is not significantly less than oligo "

--- a/bin/design.py
+++ b/bin/design.py
@@ -886,7 +886,7 @@ def design_for_id(args):
                             return False
                     return True
 
-                primer_set_filters = [has_no_heterodimers]
+                primer_set_filter_fns = [has_no_heterodimers]
             else:
                 lps = primer_search.PrimerSearcherMinimizePrimers(
                     aln, args.primer_length, args.primer_mismatches,
@@ -900,7 +900,7 @@ def design_for_id(args):
                 obj_weights=args.obj_fn_weights,
                 only_account_for_amplified_seqs=args.only_account_for_amplified_seqs,
                 halt_early=args.halt_search_early, mutator=mutator,
-                primer_set_filters=[])
+                primer_set_filter_fns=[])
             ts.find_and_write_targets(args.out_tsv[i],
                 best_n=args.best_n_targets, no_overlap=args.do_not_overlap,
                 annotations=args.annotations[i])
@@ -1466,8 +1466,8 @@ def argv_to_args(argv):
               "for a target. These specify weights for penalties on primers "
               "and amplicons relative to the guide objective. There are "
               "2 weights (A B), where the target objective function "
-              "is [(guide objective value) +/- (A*(total number of "
-              "primers) + B*log2(amplicon length)]. It is + when "
+              "is [(guide objective value) +/- (A*(primers "
+              "objective value) + B*log2(amplicon length)]. It is + when "
               "--obj is minimize-guides and - when --obj is "
               "maximize-activity."))
     parser_ct_args.add_argument('--best-n-targets', type=int, default=10,

--- a/bin/tests/test_analyze_coverage.py
+++ b/bin/tests/test_analyze_coverage.py
@@ -98,6 +98,7 @@ class TestAnalyzeCoverage(object):
             # Disable logging
             logging.disable(logging.WARNING)
 
+            # Temporarily set constants to fake values
             self.DNA_DNA_INTERNAL = thermo.DNA_DNA_INTERNAL
             self.DNA_DNA_TERMINAL = thermo.DNA_DNA_TERMINAL
             self.DNA_DNA_TERM_GC = thermo.DNA_DNA_TERM_GC
@@ -286,6 +287,8 @@ class TestAnalyzeCoverage(object):
                     os.unlink(file)
             # Re-enable logging
             logging.disable(logging.NOTSET)
+
+            # Fix modified constants and functions
             ncbi_neighbors.fetch_fastas = self.fetch_fastas
             thermo.DNA_DNA_INTERNAL = self.DNA_DNA_INTERNAL
             thermo.DNA_DNA_TERMINAL = self.DNA_DNA_TERMINAL

--- a/bin/tests/test_design.py
+++ b/bin/tests/test_design.py
@@ -232,8 +232,7 @@ class TestDesign(object):
                                  '0', '--pcr-oligo-conc', '1', '-pl', '2',
                                  '--primer-thermo', '-gl', '1',
                                  '--ideal-primer-melting-temperature',
-                                 str(PERFECT_TM),
-                                '--primer-melting-temperature-variation', '1'])
+                                 str(PERFECT_TM)])
                 else:
                     argv.extend(['--best-n-targets', '2', '-pp', '.75', '-pl',
                                  '1', '--max-primers-at-site', '2',

--- a/bin/tests/test_design.py
+++ b/bin/tests/test_design.py
@@ -7,15 +7,16 @@ import copy
 import tempfile
 import unittest
 import logging
+import math
 
 from collections import OrderedDict
 from argparse import Namespace
 from adapt import alignment
 from adapt.prepare import align, prepare_alignment, cluster
-from adapt.utils import seq_io
+from adapt.utils import seq_io, thermo
 from bin import design
 
-__author__ = 'Priya Pillai <ppillai@broadinstitute.org>'
+__author__ = 'Priya P. Pillai <ppillai@broadinstitute.org>'
 
 # Default args: window size 3, guide size 2, allow GU pairing
 # GU pairing allows AA to match GG in 1st window, and AC to
@@ -32,6 +33,54 @@ SEQS["MZ008356.1"] = "GGCTT"
 SP_SEQS = OrderedDict()
 SP_SEQS["genome_X"] = "AA---"
 
+FAKE_DNA_DNA_INSIDE ={
+    'A': {
+        'A': (1, 0.005),
+        'T': (10, 0.05),
+        'C': (1, 0.005),
+        'G': (1, 0.005),
+    },
+    'T': {
+        'A': (10, 0.05),
+        'T': (1, 0.005),
+        'C': (1, 0.005),
+        'G': (1, 0.005),
+    },
+    'C': {
+        'A': (1, 0.005),
+        'T': (1, 0.005),
+        'C': (1, 0.005),
+        'G': (10, 0.05),
+    },
+    'G': {
+        'A': (1, 0.005),
+        'T': (1, 0.005),
+        'C': (10, 0.05),
+        'G': (1, 0.005),
+    }
+}
+
+FAKE_DNA_DNA_INTERNAL = {
+    'A': FAKE_DNA_DNA_INSIDE,
+    'T': FAKE_DNA_DNA_INSIDE,
+    'C': FAKE_DNA_DNA_INSIDE,
+    'G': FAKE_DNA_DNA_INSIDE,
+}
+
+FAKE_DNA_DNA_TERMINAL = FAKE_DNA_DNA_INTERNAL
+
+FAKE_DNA_DNA_TERM_GC = (0, 0)
+
+FAKE_DNA_DNA_SYM = (0, 0)
+
+FAKE_DNA_DNA_TERM_AT = (0, 0)
+
+# With 2 bp matching, delta H is 20 and delta S is 0.1. With the thermodynamic
+# conditions set to not interfere, the melting temperature is delta H/delta S,
+# which is 200K (Note: this doesn't actually make sense in practice, as Tm
+# can't go below 0°C; this is a toy example to make testing easier)
+PERFECT_TM = 200 - thermo.CELSIUS_TO_KELVIN
+
 
 class TestDesign(object):
     """General class for testing design.py
@@ -43,6 +92,19 @@ class TestDesign(object):
         def setUp(self):
             # Disable logging
             logging.disable(logging.INFO)
+
+            # Temporarily set constants to fake values
+            self.DNA_DNA_INTERNAL = thermo.DNA_DNA_INTERNAL
+            self.DNA_DNA_TERMINAL = thermo.DNA_DNA_TERMINAL
+            self.DNA_DNA_TERM_GC = thermo.DNA_DNA_TERM_GC
+            self.DNA_DNA_SYM = thermo.DNA_DNA_SYM
+            self.DNA_DNA_TERM_AT = thermo.DNA_DNA_TERM_AT
+
+            thermo.DNA_DNA_INTERNAL = FAKE_DNA_DNA_INTERNAL
+            thermo.DNA_DNA_TERMINAL = FAKE_DNA_DNA_TERMINAL
+            thermo.DNA_DNA_TERM_GC = FAKE_DNA_DNA_TERM_GC
+            thermo.DNA_DNA_SYM = FAKE_DNA_DNA_SYM
+            thermo.DNA_DNA_TERM_AT = FAKE_DNA_DNA_TERM_AT
 
             # Create a temporary input file
             self.input_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
@@ -83,20 +145,23 @@ class TestDesign(object):
                     ei = expected[i-1]
                     if not isinstance(ei, set):
                         ei = {tuple(ei)}
-                    guide_line = line[:-1].split('\t')[col_loc]
-                    guides = guide_line.split(' ')
+                    val_line = line[:-1].split('\t')[col_loc].strip('[]')
+                    vals = val_line.split(' ')
                     an_option_is_ok = False
                     for eij in ei:
-                        is_correct = True
-                        for guide in guides:
-                            if guide not in eij:
-                                is_correct = False
-                        if len(guides) != len(eij):
+                        is_correct = False
+                        comp_fn = lambda a,b: a==b if isinstance(eij[0], str) \
+                            else lambda a,b: math.isclose(float(a.strip(',')),b)
+                        for val in vals:
+                            for eijk in eij:
+                                if comp_fn(val, eijk):
+                                    is_correct = True
+                        if len(vals) != len(eij):
                             is_correct = False
                         if is_correct:
                             an_option_is_ok = True
                     self.assertTrue(an_option_is_ok,
-                            msg=(f"The design with guides {guides} does "
+                            msg=(f"The design with {header} {vals} does "
                                 f"not match any expected solution "
                                 f"({ei})"))
                 self.assertEqual(i, len(expected))
@@ -104,7 +169,8 @@ class TestDesign(object):
         def baseArgv(self, search_type='sliding-window', input_type='fasta',
                      objective='minimize-guides', model=False, specific=None,
                      specificity_file=None, output_loc=None, unaligned=False,
-                     gp=0.75, weighted=False, allow_gu_pairing=True):
+                     gp=0.75, weighted=False, allow_gu_pairing=True,
+                     primer_thermo=False):
             """Get arguments for tests
 
             Produces the correct arguments for a test case given details of
@@ -159,10 +225,19 @@ class TestDesign(object):
                 argv.extend(['--sample-seqs', '1', '--mafft-path', 'fake_path'])
 
             if search_type == 'sliding-window':
-                argv.extend(['-w', '3'])
-            if search_type == 'complete-targets':
-                argv.extend(['--best-n-targets', '2', '-pp', '.75', '-pl', '1',
-                             '--max-primers-at-site', '2'])
+                argv.extend(['-w', '3', '-gl', '2'])
+            elif search_type == 'complete-targets':
+                if primer_thermo:
+                    argv.extend(['-na', '1', '-mg', '0', '--pcr-dntp-conc',
+                                 '0', '--pcr-oligo-conc', '1', '-pl', '2',
+                                 '--primer-thermo', '-gl', '1',
+                                 '--ideal-primer-melting-temperature',
+                                 str(PERFECT_TM),
+                                '--primer-melting-temperature-variation', '1'])
+                else:
+                    argv.extend(['--best-n-targets', '2', '-pp', '.75', '-pl',
+                                 '1', '--max-primers-at-site', '2',
+                                 '-gl', '2'])
 
             if objective == 'minimize-guides':
                 argv.extend(['-gm', '0', '-gp', str(gp)])
@@ -181,7 +256,7 @@ class TestDesign(object):
             elif objective =='maximize-activity':
                 argv.extend(['--use-simple-binary-activity-prediction', '-gm', '0'])
 
-            argv.extend(['--obj', objective, '--seed', '0', '-gl', '2'])
+            argv.extend(['--obj', objective, '--seed', '0'])
 
             return argv
 
@@ -191,6 +266,13 @@ class TestDesign(object):
                     os.unlink(file)
             # Re-enable logging
             logging.disable(logging.NOTSET)
+
+            # Fix modified constants and functions
+            thermo.DNA_DNA_INTERNAL = self.DNA_DNA_INTERNAL
+            thermo.DNA_DNA_TERMINAL = self.DNA_DNA_TERMINAL
+            thermo.DNA_DNA_TERM_GC = self.DNA_DNA_TERM_GC
+            thermo.DNA_DNA_SYM = self.DNA_DNA_SYM
+            thermo.DNA_DNA_TERM_AT = self.DNA_DNA_TERM_AT
 
 
 class TestDesignFasta(TestDesign.TestDesignCase):
@@ -250,6 +332,27 @@ class TestDesignFasta(TestDesign.TestDesignCase):
         # so 1st window changes
         expected = [{("AC", "GG"), ("AC",)}, {("CT",), ("AC",)}, ["CT"]]
         self.check_results(self.real_output_file, expected)
+
+    def test_primer_thermo(self):
+        argv = super().baseArgv(search_type='complete-targets',
+            primer_thermo=True)
+        args = design.argv_to_args(argv)
+        design.run(args)
+        expected = [{("C",)}]
+        self.check_results(self.real_output_file, expected,
+            header='guide-target-sequences')
+        expected = [{("AA", "GG")}]
+        self.check_results(self.real_output_file, expected,
+            header='left-primer-target-sequences')
+        expected = [{("CT", "TA")}]
+        self.check_results(self.real_output_file, expected,
+            header='right-primer-target-sequences')
+        expected = [{(PERFECT_TM, PERFECT_TM)}]
+        self.check_results(self.real_output_file, expected,
+            header='left-primer-ideal-melting-temperature')
+        expected = [{(PERFECT_TM, PERFECT_TM)}]
+        self.check_results(self.real_output_file, expected,
+            header='right-primer-ideal-melting-temperature')
 
 
 class TestDesignFastaUnaligned(TestDesign.TestDesignCase):


### PR DESCRIPTION
Create `TmPredictor` to see how far the predicted melting temperatures of PCR primers are from an ideal melting temperature and `PrimerSearcherMaximizeActivity` to optimize based on this predictor (and other similar ones in the future).
These are ultimately used to design PCR primers with `design.py` with the option `--primer-thermo`. Eventually, as we add more objective function options, `--primer-thermo` could take in a string to specify which objective.