### PR TITLE
Improve hash function in MinHash family

### DIFF
--- a/adapt/utils/lsh.py
+++ b/adapt/utils/lsh.py
@@ -264,13 +264,19 @@ class MinHashFamily:
                     "sequence"), self.kmer_size, len(s))
             num_kmers = len(s) - self.kmer_size + 1
             if num_kmers < self.N:
-                raise ValueError(("The number of k-mers (%d) in the given "
+                logger.warning(("The number of k-mers (%d) in a given "
                     "sequence is too small to produce a signature of "
-                    "size %d") % (num_kmers, self.N))
+                    "size %d; the MinHash family might provide unreliable "
+                    "distances against the sequence.") % (num_kmers, self.N))
             def kmer_hashes():
-                for i in range(num_kmers):
-                    kmer = s[i:(i + self.kmer_size)]
-                    yield kmer_hash(kmer)
+                num_yielded = 0
+                # Keep yielding k-mers until at least self.N
+                #   have been yielded (helpful when s is short)
+                while num_yielded < self.N:
+                    for i in range(num_kmers):
+                        kmer = s[i:(i + self.kmer_size)]
+                        num_yielded += 1
+                        yield kmer_hash(kmer)
             if self.N == 1:
                 # Speed the special case where self.N == 1
                 return tuple([min(kmer_hashes())])

--- a/adapt/utils/lsh.py
+++ b/adapt/utils/lsh.py
@@ -27,11 +27,11 @@ SOFTWARE.
 """
 
 from collections import defaultdict
+import hashlib
 import heapq
 import logging
 import math
 import random
-import zlib
 
 __author__ = 'Hayden Metsky <hayden@mit.edu>'
 
@@ -197,16 +197,22 @@ class MinHashFamily:
     The signature produced here also has similarity to Mash (Ondov et al. 2016).
     """
 
-    def __init__(self, kmer_size, N=1):
+    def __init__(self, kmer_size, N=1, use_fast_str_hash=False):
         """
         Args:
             kmer_size: length of each k-mer to hash
             N: represent the signature of a sequence using hash values of
                 the N k-mers in the sequence that have the smallest hash
                 values
+            use_fast_str_hash: if True, use a faster (~10x faster) inner
+                 hash function for strings (k-mers) that is not deterministic
+                 and varies across Python processes; this may not be
+                 appropriate if the family is shared across processes and
+                 different processes expect the same hash
         """
         self.kmer_size = kmer_size
         self.N = N
+        self.use_fast_str_hash = use_fast_str_hash
 
     def make_h(self):
         """Construct a random hash function for this family.
@@ -231,13 +237,21 @@ class MinHashFamily:
         # for random integers a, b (a in [1, p] and b in [0, p])
         a = random.randint(1, p)
         b = random.randint(0, p)
-        def kmer_hash(x):
-            # Hash a k-mer x with the random hash function
-            # hash(..) uses a random seed in Python 3.3+, so its output
-            # varies across Python processes; use zlib.adler32(..) for a
-            # deterministic hash value of the k-mer
-            x_hash = zlib.adler32(x.encode('utf-8'))
-            return (a * x_hash + b) % p
+        if self.use_fast_str_hash:
+            def kmer_hash(x):
+                # Hash a k-mer x with the random hash function
+                # hash(..) uses a random seed in Python 3.3+, so its output
+                #   varies across Python processes; thus, this may not be
+                #   suitable if used across processes
+                x_hash = abs(hash(x))
+                return (a * x_hash + b) % p
+        else:
+            def kmer_hash(x):
+                # Hash a k-mer x with the random hash function
+                # hashlib.md5(..) gives a deterministic hash value of the k-mer
+                #   but is ~10x slower than hash(..)
+                x_hash = int(hashlib.md5(x.encode('utf-8')).hexdigest(), 16)
+                return (a * x_hash + b) % p
 
         def h(s):
             # For a string/sequence s, have the MinHash function be the minimum
@@ -257,7 +271,11 @@ class MinHashFamily:
                 for i in range(num_kmers):
                     kmer = s[i:(i + self.kmer_size)]
                     yield kmer_hash(kmer)
-            return tuple(sorted(heapq.nsmallest(self.N, kmer_hashes())))
+            if self.N == 1:
+                # Speed the special case where self.N == 1
+                return tuple([min(kmer_hashes())])
+            else:
+                return tuple(sorted(heapq.nsmallest(self.N, kmer_hashes())))
         return h
 
     def P1(self, dist):

--- a/adapt/utils/tests/test_lsh.py
+++ b/adapt/utils/tests/test_lsh.py
@@ -26,6 +26,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+import logging
 import random
 import unittest
 
@@ -204,6 +205,9 @@ class TestMinHashFamilySignatures(unittest.TestCase):
     """
 
     def setUp(self):
+        # Disable logging
+        logging.disable(logging.WARNING)
+        
         # Set a random seed so hash functions are always the same
         random.seed(0)
 
@@ -219,6 +223,30 @@ class TestMinHashFamilySignatures(unittest.TestCase):
             h = self.family.make_h()
             self.assertEqual(h(a), h(b))
             self.assertEqual(self.family.estimate_jaccard_dist(h(a), h(b)), 0.0)
+
+    def test_identical_with_short_sequences(self):
+        a = 'ATCGA'
+        b = str(a)
+
+        # Identical strings should yield the same signature, for the same
+        # hash function
+        for i in range(10):
+            h = self.family.make_h()
+            self.assertEqual(h(a), h(b))
+            self.assertEqual(self.family.estimate_jaccard_dist(h(a), h(b)), 0.0)
+
+    def test_identical_with_short_sequences_fast_hash(self):
+        family_1 = lsh.MinHashFamily(4, N=10, use_fast_str_hash=True)
+
+        a = 'ATCGA'
+        b = str(a)
+
+        # Identical strings should yield the same signature, for the same
+        # hash function
+        for i in range(10):
+            h = self.family.make_h()
+            self.assertEqual(h(a), h(b))
+            self.assertEqual(family_1.estimate_jaccard_dist(h(a), h(b)), 0.0)
 
     def test_jaccard_dist_similar(self):
         a = 'ATCGATATGGGCACTGCTATGTAGCGCAAATACGATCGCTAATGCGGATCGGATCGAATG'


### PR DESCRIPTION
This PR makes several small changes designed to improve the behavior of the MinHash family's hash functions:

- Changes their inner function, used for strings (k-mers), from Adler-32 to md5 [5f8f54e]
- Updates the construction of sequence signatures to tolerate sequences that were previously considered too short (i.e., too few k-mers for the signature) [c85d1d6]

It is based on [PR #45](https://github.com/broadinstitute/catch/pull/45) in the CATCH repository.